### PR TITLE
Menu hover text display/no display

### DIFF
--- a/include/common.php
+++ b/include/common.php
@@ -1504,7 +1504,7 @@ class common{
 	 * @param string $title
 	 *
 	 */
-	function GetBrowserTitle($title){
+	function GetBrowserTitle($title,$menu_item=false){
 		global $gp_titles, $gp_index;
 
 		if( !isset($gp_index[$title]) ){
@@ -1516,6 +1516,10 @@ class common{
 
 		if( isset($title_info['browser_title']) ){
 			return $title_info['browser_title'];
+		}
+		
+		if (($menu_item == TRUE) && (isset($title_info['browser_title_no_hover_text']))) {
+		  return ''; //blank means no hint will be displayed
 		}
 
 		$label = common::GetLabel($title);

--- a/include/languages/en/main.inc
+++ b/include/languages/en/main.inc
@@ -500,5 +500,5 @@ continue using your old password.</p>',
 'Select Image'=>'Select Image',
 'Theme Images'=>'Theme Images',
 'restore_backup' => 'Restore Backup',
-
+'hide_menu_hover_text' => 'Hide menu hover text',
 );

--- a/include/tool/Page_Rename.php
+++ b/include/tool/Page_Rename.php
@@ -88,11 +88,16 @@ class gp_rename{
 				$attr = 'disabled="disabled" ';
 				$class .= ' sync_label';
 			}
+			if ((isset($title_info['browser_title_no_hover_text']) ) && ($title_info['browser_title_no_hover_text'] == '1')) {
+				$browser_title_no_hover_text = 'checked="checked"';
+			}else{
+				$browser_title_no_hover_text = "";
+			}
 			echo '<td class="formlabel">';
 			echo $langmessage['browser_title'];
 			echo '</td>';
 			echo '<td>';
-			echo '<input type="text" class="'.$class.' gpinput" size="50" name="browser_title" value="'.$browser_title.'" '.$attr.'/>';
+			echo '<input type="text" class="'.$class.' gpinput" size="50" name="browser_title" value="'.$browser_title.'" '.$attr.'/><br/><input type="checkbox" name="browser_title_no_hover_text" '.$browser_title_no_hover_text.' value="1"> '.$langmessage['hide_menu_hover_text']; //Show menu hover text
 			echo ' <div class="label_synchronize">';
 			if( empty( $attr ) ){
 				echo '<a href="#">'.$langmessage['sync_with_label'].'</a>';
@@ -257,6 +262,11 @@ class gp_rename{
 		}
 		if( !$custom_browser_title ){
 			unset($title_info['browser_title']);
+		}
+		if( isset($_POST['browser_title_no_hover_text']) ){
+		  $title_info['browser_title_no_hover_text'] = '1';
+		} else {
+		  unset($title_info['browser_title_no_hover_text']);
 		}
 
 		//keywords

--- a/include/tool/gpOutput.php
+++ b/include/tool/gpOutput.php
@@ -1492,7 +1492,7 @@ class gpOutput{
 					$replace[] = common::GetUrl($title);
 					$replace[] = $attr;
 					$replace[] = common::GetLabel($title);
-					$replace[] = common::GetBrowserTitle($title);
+					$replace[] = common::GetBrowserTitle($title,true);
 				}
 
 				$result[] = '<li'.$attr_li.'>'.str_replace($search,$replace,$link_format);


### PR DESCRIPTION
Regarding request 

http://gpeasy.com/Feedback?id=30

Added checkbox under browser title in page properties (rename/details) dialog
called 'Hide menu hover text'

When checkbox is checked menu items will not have any hover text when a mouse is
over the item.