### PR TITLE
Update galleries with new files names if image file is renamed.

### DIFF
--- a/include/admin/admin_uploaded.php
+++ b/include/admin/admin_uploaded.php
@@ -836,11 +836,10 @@ class admin_uploaded{
 		$base_dir = $dataDir.'/data/_uploaded';
 		$thumb_dir = $dataDir.'/data/_uploaded/image/thumbnails';
 		admin_uploaded::SetRealPath($result,$elfinder);
-        
 		switch($cmd){
-
+  
 			case 'rename':
-			admin_uploaded::RenameResized($result['removed'][0],$result['added'][0]);
+			admin_uploaded::RenameResized($result['removed'][0],$result['added'][0],$result);
 			break;
 
 			case 'rm':
@@ -968,9 +967,24 @@ class admin_uploaded{
 	 * Update the name of an image in the index when renamed
 	 *
 	 */
-	function RenameResized($removed,$added){
+	function RenameResized($removed,$added,$result = NULL){
+	    global $dataDir;
 		$added_img = admin_uploaded::TrimBaseDir($added['realpath']);
 		$removed_img = admin_uploaded::TrimBaseDir($removed['realpath']);
+
+	    if ($result != NULL) { //johannes added for dir rename in image folder to sync with thumbnails
+		  if ($result['removed'][0]['mime'] == 'directory') {
+			$added_img = str_replace('\\','/',$added_img);
+			$removed_img = str_replace('\\','/',$removed_img);
+			//directory name was changed inside image but not in thumbnails
+			if ((strpos($added_img,'image/') !== FALSE) && (strpos($added_img,'image/thumbnails/') === FALSE)) { 
+				$thmbD = $dataDir.'/data/_uploaded/image/thumbnails';
+				$oldDir = $thmbD.$removed_img;
+				$newDir = $thmbD.$added_img;
+				rename($oldDir,$newDir);
+			}
+		  }	  
+		}
 		
         //update gallery
 		admin_uploaded::UpdateGalleriesImages($added_img,$removed_img);

--- a/include/admin/admin_uploaded.php
+++ b/include/admin/admin_uploaded.php
@@ -836,7 +836,7 @@ class admin_uploaded{
 		$base_dir = $dataDir.'/data/_uploaded';
 		$thumb_dir = $dataDir.'/data/_uploaded/image/thumbnails';
 		admin_uploaded::SetRealPath($result,$elfinder);
-
+        
 		switch($cmd){
 
 			case 'rename':
@@ -1003,6 +1003,10 @@ class admin_uploaded{
 		   $meta_data = array();
 		   
 		   $file = $dataDir.'/data/_pages/'.substr($config['gpuniq'],0,7).'_'.$gp_index[$title].'.php';
+		   if (!file_exists($file)) {
+		     $file = $dataDir.'/data/_pages/'.str_replace('/','_',$title).'.php';
+		   }
+		   
 		   include $file;
 		   $changemade = false;
 		   foreach ($file_sections as $key=>$val) {

--- a/include/admin/admin_uploaded.php
+++ b/include/admin/admin_uploaded.php
@@ -987,8 +987,10 @@ class admin_uploaded{
 	   //used for file renames mostly, thus expect newImg and oldImg to be in format
 	   //   /image/filename.ext
 	   //thus path from data/_uploads to file
-	  $galleries = array();
-		global $dataDir,$config,$gp_index;
+	   global $dataDir,$config,$gp_index;
+	   if (!file_exists($dataDir.'/data/_site/galleries.php')) { return; } //no galleries setup in pages
+	   
+	    $galleries = array();
 		include $dataDir.'/data/_site/galleries.php';
 		$ext = '.'.end(explode('.', $newImg));
 		$newImgName = str_replace(' ','%20',str_replace('\\','/',$newImg));

--- a/include/thirdparty/elfinder/connector.php
+++ b/include/thirdparty/elfinder/connector.php
@@ -30,7 +30,7 @@ includeFile('thirdparty/elfinder/php/elFinderVolumeLocalFileSystem.class.php');
 function access($attr, $path, $data, $volume) {
 	//gpEasy thumbnails
 	$path = str_replace('\\','/',$path);
-	if( $attr == 'write' && strpos($path,'/image/thumbnails/') != false ){
+	if( $attr == 'write' && strpos($path,'/image/thumbnails') != false ){
 		return false;
 	}
 	return null;

--- a/include/thirdparty/elfinder/connector.php
+++ b/include/thirdparty/elfinder/connector.php
@@ -28,7 +28,6 @@ includeFile('thirdparty/elfinder/php/elFinderVolumeLocalFileSystem.class.php');
  * @return bool|null
  **/
 function access($attr, $path, $data, $volume) {
-
 	//gpEasy thumbnails
 	if( $attr == 'write' && strpos($path,'/image/thumbnails/') !== false ){
 		return false;

--- a/include/thirdparty/elfinder/connector.php
+++ b/include/thirdparty/elfinder/connector.php
@@ -29,7 +29,8 @@ includeFile('thirdparty/elfinder/php/elFinderVolumeLocalFileSystem.class.php');
  **/
 function access($attr, $path, $data, $volume) {
 	//gpEasy thumbnails
-	if( $attr == 'write' && strpos($path,'/image/thumbnails/') !== false ){
+	$path = str_replace('\\','/',$path);
+	if( $attr == 'write' && strpos($path,'/image/thumbnails/') != false ){
 		return false;
 	}
 	return null;

--- a/include/thirdparty/elfinder/php/elFinder.class.php
+++ b/include/thirdparty/elfinder/php/elFinder.class.php
@@ -174,7 +174,7 @@ class elFinder {
 	public function __construct($opts) {
 		if (session_id() == '') {
 		    register_shutdown_function('session_write_close');
-			session_start();
+//			session_start();
 		}
 		$this->time  = $this->utime();
 		$this->debug = (isset($opts['debug']) && $opts['debug'] ? true : false);
@@ -413,7 +413,12 @@ class elFinder {
 	 * @author Dmitry (dio) Levashov
 	 */
 	protected function getNetVolumes() {
-		return isset($_SESSION['elFinderNetVolumes']) && is_array($_SESSION['elFinderNetVolumes']) ? $_SESSION['elFinderNetVolumes'] : array();
+		if (session_id() == '') {
+			session_start();
+		}
+		$result = isset($_SESSION['elFinderNetVolumes']) && is_array($_SESSION['elFinderNetVolumes']) ? $_SESSION['elFinderNetVolumes'] : array();
+		session_write_close();
+		return $result;
 	}
 
 	/**
@@ -424,7 +429,11 @@ class elFinder {
 	 * @author Dmitry (dio) Levashov
 	 */
 	protected function saveNetVolumes($volumes) {
+		if (session_id() == '') {
+			session_start();
+		}
 		$_SESSION['elFinderNetVolumes'] = $volumes;
+		session_write_close();
 	}
 
 	/***************************************************************************/

--- a/include/thirdparty/elfinder/php/elFinder.class.php
+++ b/include/thirdparty/elfinder/php/elFinder.class.php
@@ -175,28 +175,23 @@ class elFinder {
 		if (session_id() == '') {
 			session_start();
 		}
-
 		$this->time  = $this->utime();
 		$this->debug = (isset($opts['debug']) && $opts['debug'] ? true : false);
 		
 		setlocale(LC_ALL, !empty($opts['locale']) ? $opts['locale'] : 'en_US.UTF-8');
-
 		// bind events listeners
 		if (!empty($opts['bind']) && is_array($opts['bind'])) {
 			foreach ($opts['bind'] as $cmd => $handler) {
 				$this->bind($cmd, $handler);
 			}
 		}
-
 		if (!isset($opts['roots']) || !is_array($opts['roots'])) {
 			$opts['roots'] = array();
 		}
-
 		// check for net volumes stored in session
 		foreach ($this->getNetVolumes() as $root) {
 			$opts['roots'][] = $root;
 		}
-
 		// "mount" volumes
 		foreach ($opts['roots'] as $i => $o) {
 			$class = 'elFinderVolume'.(isset($o['driver']) ? $o['driver'] : '');
@@ -219,7 +214,6 @@ class elFinder {
 				$this->mountErrors[] = 'Driver "'.$class.'" does not exists';
 			}
 		}
-
 		// if at least one redable volume - ii desu >_<
 		$this->loaded = !empty($this->default);
 	}

--- a/include/thirdparty/elfinder/php/elFinder.class.php
+++ b/include/thirdparty/elfinder/php/elFinder.class.php
@@ -173,6 +173,7 @@ class elFinder {
 	 **/
 	public function __construct($opts) {
 		if (session_id() == '') {
+		    register_shutdown_function('session_write_close');
 			session_start();
 		}
 		$this->time  = $this->utime();

--- a/include/thirdparty/elfinder/php/elFinderConnector.class.php
+++ b/include/thirdparty/elfinder/php/elFinderConnector.class.php
@@ -35,7 +35,6 @@ class elFinderConnector {
 	 * @author Dmitry (dio) Levashov
 	 **/
 	public function __construct($elFinder, $debug=false) {
-		
 		$this->elFinder = $elFinder;
 		if ($debug) {
 			$this->header = 'Content-Type: text/html; charset=utf-8';


### PR DESCRIPTION
This will update all galleries with new file name for image if name changed.

this also tries to fix some bugs in elFinder
https://github.com/Studio-42/elFinder/issues/417
https://github.com/Studio-42/elFinder/pull/416

NOTE : that for issue 416
I found a better reason (more logical) and solution for this

make sure mime_magic.magicfile is set else this gives problems on windows set to mime_magic.magicfile = "$PHP_INSTALL_DIR\magic.mime"

But the problem here is, IF elFinder crashes in any way weirdly when doing something
it does not close the session and one can get session logs, this results in
the Open Directory haning scenario. We need to hook into the shutdown and add
code that IF a session is active, it closes it. hopefully that will fix it.