### PR TITLE
Added default Sizes button to image editor form

### DIFF
--- a/include/admin/admin_theme_content.php
+++ b/include/admin/admin_theme_content.php
@@ -3345,6 +3345,8 @@ class admin_theme_content extends admin_addon_install{
 		ob_start();
 
 		echo '<div id="gp_current_image">';
+		echo '<input type="hidden" name="orig_height">';
+		echo '<input type="hidden" name="orig_width">';
 		echo '<span id="gp_image_wrap"><img/></span>';
 		echo '<table>';
 		echo '<tr><td>'.$langmessage['Width'].'</td><td><input type="text" name="width" class="ck_input"/></td>';
@@ -3358,6 +3360,7 @@ class admin_theme_content extends admin_addon_install{
 		echo '<b>'.$langmessage['Select Image'].'</b>';
 		echo '<a class="ckeditor_control half_width" name="show_theme_images">'.$langmessage['Theme Images'].'</a>';
 		echo '<a class="ckeditor_control half_width" name="show_uploaded_images">'.$langmessage['uploaded_files'].'</a>';
+		echo '<a class="ckeditor_control half_width" name="deafult_sizes">'.$langmessage['Theme_default_sizes'].'</a>';		
 		echo '</div>';
 
 		echo '<div id="gp_image_area"></div><div id="gp_upload_queue"></div>';

--- a/include/js/inline_edit/image_edit.js
+++ b/include/js/inline_edit/image_edit.js
@@ -65,6 +65,8 @@
 			edit_img.attr('src','');
 			var width = edit_img.width();
 			var height = edit_img.height()
+			$('#gp_current_image input[name=orig_width]').val( width );
+			$('#gp_current_image input[name=orig_height]').val( height );
 			SetCurrentImage( img_src, width, height );
 			SetupDrag();
 
@@ -184,6 +186,11 @@
 		gplinks.show_theme_images = function(){
 			var path = strip_from(gp_editor.save_path,'?')+'?cmd=theme_images';
 			$gp.jGoTo(path);
+		}
+		gplinks.deafult_sizes = function(){
+			$('#gp_current_image input[name=width]').val( $('#gp_current_image input[name=orig_width]').val());
+			$('#gp_current_image input[name=height]').val( $('#gp_current_image input[name=orig_height]').val());
+			$('#gp_current_image input[name=width]').change();
 		}
 
 

--- a/include/languages/en/main.inc
+++ b/include/languages/en/main.inc
@@ -509,4 +509,6 @@ continue using your old password.</p>',
 'strftime_time'=>'%H:%M',
 
 '_characters' => '%s characters',
+'Theme_default_sizes' => 'Default Size',
+
 );


### PR DESCRIPTION
Pressing defualt sizes will change the selected image size to that specefied by
the selected image for editing. thus allows user to go back to theme
developers original size if it was not previouly overridden with image edit.

Still to look if can maybe have a fixed image size specified by theme developer
