### PR TITLE
Allow multi custom images per theme

### DIFF
--- a/include/admin/admin_theme_content.php
+++ b/include/admin/admin_theme_content.php
@@ -3386,7 +3386,7 @@ class admin_theme_content extends admin_addon_install{
 		includeFile('tool/Images.php');
 		includeFile('tool/editing.php');
 		$page->ajaxReplace = array();
-		$dest_dir = $dataDir.'/data/_layouts/'.$this->curr_layout;
+		//$dest_dir = $dataDir.'/data/_layouts/'.$this->curr_layout; //Not used anywhere.
 
 
 		//source file
@@ -3489,7 +3489,7 @@ class admin_theme_content extends admin_addon_install{
 		$save_info['height'] = $height;
 
 		$container = $_REQUEST['container'];
-		$gpLayouts[$this->curr_layout]['images'] = array(); //prevents shuffle
+		//$gpLayouts[$this->curr_layout]['images'] = array(); //prevents shuffle - REMOVED to allow images per container to be saved.
 		$gpLayouts[$this->curr_layout]['images'][$container] = array(); //prevents shuffle
 		$gpLayouts[$this->curr_layout]['images'][$container][] = $save_info;
 

--- a/include/tool/gpOutput.php
+++ b/include/tool/gpOutput.php
@@ -1126,8 +1126,8 @@ class gpOutput{
 			&& is_array($gpLayouts[$page->gpLayout]['images'][$container_id])
 			){
 				//echo showArray($gpLayouts[$page->gpLayout]['images'][$container_id]);
-				shuffle($gpLayouts[$page->gpLayout]['images'][$container_id]);
-				$image = current($gpLayouts[$page->gpLayout]['images'][$container_id]);
+				//shuffle($gpLayouts[$page->gpLayout]['images'][$container_id]); //Does not make sense ? There will always be only 1 entry in for this container as it is per img element
+				$image = $gpLayouts[$page->gpLayout]['images'][$container_id][0]; //call to current also not needed, there will only be 1 entry
 				$img_full = $dataDir.$image['img_rel'];
 				if( file_exists($img_full) ){
 					$img_rel = $image['img_rel'];


### PR DESCRIPTION
Changed to allow each container to be saved per theme and not just 1 container per theme
this allows the theme to have multiple images that is customized and remembered correctly.

also solves this weird shuffle problem as per this forum entry

http://gpeasy.com/Special_Forum?show=t1056
