### PR TITLE
trim ns character

### DIFF
--- a/include/tool.php
+++ b/include/tool.php
@@ -213,7 +213,8 @@ namespace gp{
 		 */
 		public static function Autoload($class){
 			global $config, $dataDir;
-
+			
+			$class		= trim($class,'\\');
 			$parts		= explode('\\',$class);
 			$part_0		= array_shift($parts);
 


### PR DESCRIPTION
fixes autoloading for older windows installations