### PR TITLE
Update Child_Thumbnails.php

### DIFF
--- a/addons/--Child_Thumbnails/Child_Thumbnails.php
+++ b/addons/--Child_Thumbnails/Child_Thumbnails.php
@@ -98,7 +98,12 @@ class Child_Thumbnails{
 		//prevent infinite loops
 		foreach($file_sections as $key=>$val){
 			if($val['type']=='include'){
-				unset($file_sections[$key]);
+			//dummy section instead of include
+			$file_sections[$key] =   array (
+			'type' => 'text',
+			'content' => '<div><p>Lorem ipsum </p></div>',
+			'attributes' => array (), );
+        }
 			}
 		}
 


### PR DESCRIPTION
In TS 5 unseting include section cause to user  notice and throw  $section_data is NULL. Array expected and  notice Undefined offset: 11    iinclude\tool\Output\Sections.php   on line: 42 (on parent page when included section on child page)
I think this change  would be good.