### PR TITLE
trigger substitute event to be used in plugins JS

### DIFF
--- a/include/js/admin.js
+++ b/include/js/admin.js
@@ -918,6 +918,8 @@ $(function(){
 
 			if( new_area.parent().closest('.editable_area').length > 0 ){
 				e.stopPropagation();
+				// trigger a substitute event, plugin JS can listen to
+				new_area.trigger("admin:" + e.type);
 			}
 
 			//area han't changed, so just show the span


### PR DESCRIPTION
... since original event bubbling is blocked with stopPropagation() with this substitute event we can listen to e.g. admin:mouseenter