### PR TITLE
Custom Combo Label

### DIFF
--- a/include/Page/Edit.php
+++ b/include/Page/Edit.php
@@ -656,6 +656,25 @@ class Edit extends \gp\Page{
 
 
 	/**
+	 * Get nested types by recursion
+	 *
+	 */
+	public static function GetNestedTypes($types){
+		$return = $types;
+		foreach( $types as $key => $type ){
+			$wrapper_class = isset($type[1]) ? $type[1] : '';
+      		$label = isset($type[2]) ? $type[2] : '';
+			if( count($type) > 1 ){
+				$return[$key] = array('types'=>self::GetNestedTypes($type[0]), 'wrapper_class'=>$wrapper_class, 'label'=>$label);
+			}else{
+				$return[$key] = $type;
+			}
+		}
+		return $return;
+	}
+
+
+	/**
 	 * Add link to manage section admin for nested section type
 	 *
 	 */
@@ -677,8 +696,8 @@ class Edit extends \gp\Page{
 
 
 			if( count($types) > 1 ){
-				$q		= array('types' => $types, 'wrapper_class'=>$wrapper_class, 'label'=>$text_label);
-				$q		= json_encode($q);
+				$q = array('types' => self::GetNestedTypes($types), 'wrapper_class'=>$wrapper_class, 'label'=>$text_label);
+				$q = json_encode($q);
 			}else{
 				$q		= $types[0];
 			}

--- a/include/Page/Edit.php
+++ b/include/Page/Edit.php
@@ -335,7 +335,7 @@ class Edit extends \gp\Page{
 	 * Send multiple sections to the client
 	 *
 	 */
-	public function NewNestedSection($types, $wrapper_class ){
+	public function NewNestedSection($types, $wrapper_class, $custom_combo_label=false){
 		global $langmessage;
 
 		$new_section		= \gp\tool\Editing::DefaultContent('wrapper_section');
@@ -349,9 +349,9 @@ class Edit extends \gp\Page{
 		foreach($types as $type){
 			if( is_array($type) ){
 				$_wrapper_class = isset($type[1]) ? $type[1] : '';
-				$output .= $this->NewNestedSection($type[0], $_wrapper_class);
+				$output .= $this->NewNestedSection($type[0], $_wrapper_class, $custom_combo_label);
 			}else{
-				$output .= $this->GetNewSection($type);
+				$output .= $this->GetNewSection($type, $custom_combo_label);
 			}
 
 		}
@@ -360,11 +360,11 @@ class Edit extends \gp\Page{
 		return $output;
 	}
 
-	public function GetNewSection($type){
+	public function GetNewSection($type, $custom_combo_label=false){
 
 		$class			= self::TypeClass($type);
 		$num			= time().rand(0,10000);
-		$new_section	= \gp\tool\Editing::DefaultContent($type);
+		$new_section	= \gp\tool\Editing::DefaultContent($type, NULL, $custom_combo_label);
 		$content		= \gp\tool\Output\Sections::RenderSection($new_section,$num,$this->title,$this->file_stats);
 
 		$new_section['attributes']['class']		.= ' '.$class;
@@ -649,8 +649,8 @@ class Edit extends \gp\Page{
 		$links				= \gp\tool\Plugins::Filter('NewSections',array($links));
 
 		foreach($links as $link){
-			$link += array('','','gpRow');
-			echo self::NewSectionLink( $link[0], $link[1], $link[2], $checkboxes );
+			$link += array('','','gpRow',false);
+			echo self::NewSectionLink( $link[0], $link[1], $link[2], $link[3], $checkboxes );
 		}
 	}
 
@@ -659,12 +659,12 @@ class Edit extends \gp\Page{
 	 * Add link to manage section admin for nested section type
 	 *
 	 */
-	public static function NewSectionLink($types, $img, $wrapper_class = 'gpRow', $checkbox = false ){
+	public static function NewSectionLink($types, $img, $wrapper_class = 'gpRow', $custom_combo_label=false, $checkbox = false ){
 		global $dataDir, $page;
 		static $fi = 0;
 
 		$types			= (array)$types;
-		$text_label		= self::SectionLabel($types);
+		$text_label		= $custom_combo_label ? $custom_combo_label : self::SectionLabel($types);
 
 		$label			= '';
 		if( !empty($img) ){
@@ -677,7 +677,7 @@ class Edit extends \gp\Page{
 
 
 			if( count($types) > 1 ){
-				$q		= array('types' => $types,'wrapper_class'=>$wrapper_class);
+				$q		= array('types' => $types, 'wrapper_class'=>$wrapper_class, 'label'=>$text_label);
 				$q		= json_encode($q);
 			}else{
 				$q		= $types[0];
@@ -705,7 +705,7 @@ class Edit extends \gp\Page{
 		//links used for new sections
 		$attrs					= array('data-cmd'=>'AddSection','class'=>'preview_section');
 		if( count($types) > 1 ){
-			$attrs['data-response']	= $page->NewNestedSection($types, $wrapper_class);
+			$attrs['data-response']	= $page->NewNestedSection($types, $wrapper_class, $text_label);
 		}else{
 			$attrs['data-response']	= $page->GetNewSection($types[0]);
 		}


### PR DESCRIPTION
Allows to define a custom Section Combo label in NewSections hook like 

  function NewSections($links){
    [...]
    $links[] = array(
      array( 
        'text.gpCol-4', // sectionType.className
        'text.gpCol-4', // sectionType.className
        'text.gpCol-4', // sectionType.className
      ), 
      $addonRelativeCode . '/icon/section-combo.png', // icon
      'gpRow', // SectionWrapper className
      **'3 Text Rows', // Custom Section Combo Label**
    );
    [...]
}

The new label will be used in the New Sections selection (Section Manager and Create Page).
When a new Section Combo is created, the label will be passed to the DefaultContent filter hook as 3rd argument:

DefaultContent($default_content, $type, $custom_combo_label=''){ [...] }

This way we can filter it together with $type and provide custom default content (and even attributes) for every section in this particular combo context. Gives us full control of sections and allows us to build sophisticated Combos.

