### PR TITLE
Multi Nested Combos - fix 2/2

### DIFF
--- a/include/Page/Edit.php
+++ b/include/Page/Edit.php
@@ -739,7 +739,7 @@ class Edit extends \gp\Page{
 
 		$class = '';
 
-		if( strpos($type,'.') ){
+		if( !is_array($type) && strpos($type,'.') ){
 			list($type,$class) = explode('.',$type,2);
 		}
 

--- a/include/Page/Edit.php
+++ b/include/Page/Edit.php
@@ -698,7 +698,7 @@ class Edit extends \gp\Page{
 
 		//links used for new sections
 		$attrs					= array('data-cmd'=>'AddSection','class'=>'preview_section');
-		if( count($types) > 1 ){
+		if( count($types) > 1 || is_array($types[0]) ){
 			$attrs['data-response']	= $page->NewNestedSection($types, $wrapper_class);
 		}else{
 			$attrs['data-response']	= $page->GetNewSection($types[0]);

--- a/include/Page/Edit.php
+++ b/include/Page/Edit.php
@@ -658,6 +658,7 @@ class Edit extends \gp\Page{
 
 		$types			= (array)$types;
 		$text_label		= self::SectionLabel($types);
+		$type_id = substr( base_convert( md5( json_encode( $types ) ), 16, 32 ), 0, 6);
 
 		$label			= '';
 		if( !empty($img) ){
@@ -669,7 +670,7 @@ class Edit extends \gp\Page{
 		if( $checkbox ){
 
 
-			if( count($types) > 1 ){
+			if( count($types) > 1 || is_Array($types[0]) ){
 				$q		= array('types' => $types,'wrapper_class'=>$wrapper_class);
 				$q		= json_encode($q);
 			}else{
@@ -687,7 +688,7 @@ class Edit extends \gp\Page{
 			}
 
 			$id		= 'checkbox_'.md5($q);
-			echo '<div>';
+			echo '<div data-type_id="' . $type_id . '">';
 			echo '<input name="content_type" type="radio" value="'.htmlspecialchars($q).'" id="'.$id.'" required '.$checked.' />';
 			echo '<label for="'.$id.'">';
 			echo $label;
@@ -703,7 +704,7 @@ class Edit extends \gp\Page{
 			$attrs['data-response']	= $page->GetNewSection($types[0]);
 		}
 
-		return '<div><a '.\gp\tool::LinkAttr($attrs,$label).'>'.$label.'</a></div>';
+		return '<div data-type_id="' . $type_id . '"><a '.\gp\tool::LinkAttr($attrs,$label).'>'.$label.'</a></div>';
 	}
 
 	/**

--- a/include/Page/Edit.php
+++ b/include/Page/Edit.php
@@ -670,7 +670,7 @@ class Edit extends \gp\Page{
 		if( $checkbox ){
 
 
-			if( count($types) > 1 || is_Array($types[0]) ){
+			if( count($types) > 1 || is_array($types[0]) ){
 				$q		= array('types' => $types,'wrapper_class'=>$wrapper_class);
 				$q		= json_encode($q);
 			}else{

--- a/include/Page/Edit.php
+++ b/include/Page/Edit.php
@@ -688,7 +688,7 @@ class Edit extends \gp\Page{
 			}
 
 			$id		= 'checkbox_'.md5($q);
-			echo '<div data-type_id="' . $type_id . '">';
+			echo '<div data-type-id="' . $type_id . '">';
 			echo '<input name="content_type" type="radio" value="'.htmlspecialchars($q).'" id="'.$id.'" required '.$checked.' />';
 			echo '<label for="'.$id.'">';
 			echo $label;
@@ -704,7 +704,7 @@ class Edit extends \gp\Page{
 			$attrs['data-response']	= $page->GetNewSection($types[0]);
 		}
 
-		return '<div data-type_id="' . $type_id . '"><a '.\gp\tool::LinkAttr($attrs,$label).'>'.$label.'</a></div>';
+		return '<div data-type-id="' . $type_id . '"><a '.\gp\tool::LinkAttr($attrs,$label).'>'.$label.'</a></div>';
 	}
 
 	/**


### PR DESCRIPTION
If a multi-nested Section Combo is defined where a wrapper only contains another wrapper (and no other regular sections), 2 warnings get thrown into the sections list. This is probably not treating the underlying cause but rather symptoms. If so I'm sorry for that -  I currently don't have much time. Anyway, the file changes prevent the warnings.


Sample Code for testing:

```
static function NewSections($links){
    global $addonRelativeCode;

    $links[] = array( // new section entry
      0 => array( // level 0 items array
        0 => array( // level 1 item 0: wrapper
          0 => array( // level 1 items array
            'CustomCombo01-text.gpCol-6',   // pseudo-section-type.section class name(s)
            'CustomCombo01-text.gpCol-6',   // pseudo-section-type.section class name(s)
          ),
          1 => 'inner_wrapper_class', 
        ),
      ), // end of level 0 items array
      1 => $addonRelativeCode . '/ui_icons/CustomCombo-w_w_t6-t6.png', // section combo icon
      2 => 'outer_wrapper_class', // wrapper class name(s)
    );

}
```