### PR TITLE
ToggleVisibility Admin Link -> red warning color

### DIFF
--- a/include/css/admin.scss
+++ b/include/css/admin.scss
@@ -344,6 +344,14 @@
 	background: lighten($gp_panel_bg,10%);
 	}
 
+#admincontent_panel a[href$='ToggleVisibility'] { 
+	background:#C44830; 
+	}
+
+#admincontent_panel a[href$='ToggleVisibility']:hover { 
+	background:#DC5135; 
+	}
+
 #admincontent_panel span > .fa,
 #admincontent_panel a > .fa{
 	margin-right: 4px;


### PR DESCRIPTION
... if the current page is set to Visibility: Private. 
Users sometimes click this link by accident and only notice that the page is missing when they're logged out.
