### PR TITLE
Compress cached files for SCSS

### DIFF
--- a/include/tool/Output/Css.php
+++ b/include/tool/Output/Css.php
@@ -120,6 +120,8 @@ class Css{
 			}
 
 			$compiler->addImportPath($dataDir);
+			// set 'compressed' format for compiled css
+			$compiler->setFormatter('Leafo\ScssPhp\Formatter\Compressed');
 
 			$compiled = $compiler->compile(implode("\n",$combined));
 


### PR DESCRIPTION
It sets 'compressed' format for SCSS compiler and 
minifies data/_cache/scss_*.css files regardless of theme scss format