### PR TITLE
LESS - set 'compressed' format for compiled css

### DIFF
--- a/include/tool/Output/Css.php
+++ b/include/tool/Output/Css.php
@@ -172,6 +172,8 @@ class Css{
 
 		//compiler options
 		$options = array();
+		// set 'compressed' format for compiled css
+		$options['compress'] = 'true';
 
 		//prepare the compiler
 		includeFile('thirdparty/less.php/Less.php');


### PR DESCRIPTION
It sets 'compressed' format for less_*.css compiled from .less files. So Google PageSpeed Insights will be happy.