### PR TITLE
Asynchronous CSS loading 

### DIFF
--- a/include/tool/Output.php
+++ b/include/tool/Output.php
@@ -1800,7 +1800,10 @@ namespace gp\tool{
 
 					$html = "\n".'<script type="text/javascript" src="%s"></script>';
 					if( $type == 'css' ){
-						$html = "\n".'<link type="text/css" href="%s" rel="stylesheet"/>';
+//						$html = "\n".'<link type="text/css" href="%s" rel="stylesheet"/>';
+//vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+						$html = "\n".'<link rel="preload" as="style" type="text/css" href="%s" onload="this.rel=\'stylesheet\'"/>';
+//!!!!!!!!^^^^^^^^^^^^^^^^ asinchronous css loading
 					}
 
 					\gp\tool\Output\Combine::CheckFile($file);
@@ -1815,7 +1818,10 @@ namespace gp\tool{
 
 			$html = "\n".'<script type="text/javascript" src="%s"></script>';
 			if( $type == 'css' ){
-				$html = "\n".'<link rel="stylesheet" type="text/css" href="%s"/>';
+//				$html = "\n".'<link rel="stylesheet" type="text/css" href="%s"/>';
+//vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+				$html = "\n".'<link rel="preload" as="style" type="text/css" href="%s" onload="this.rel=\'stylesheet\'"/>';
+//!!!!!!!!^^^^^^^^^^^^^^^^ asinchronous css loading
 			}
 
 			//create combine request

--- a/include/tool/Plugins.php
+++ b/include/tool/Plugins.php
@@ -58,7 +58,10 @@ namespace gp\tool{
 			}
 
 			if( $path !== false ){
-				$page->head			.= "\n".'<link rel="stylesheet" type="text/css" href="'.\gp\tool::GetDir($path).'"/>';
+//				$page->head			.= "\n".'<link rel="stylesheet" type="text/css" href="'.\gp\tool::GetDir($path).'"/>';
+//vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+				$page->head			.= "\n".'<link rel="preload" as="style" type="text/css" href="'.\gp\tool::GetDir($path).'" onload="this.rel=\'stylesheet\'"/>';
+//!!!!!!!!^^^^^^^^^^^^^^^^ asinchronous css loading
 			}
 
 			return $path;


### PR DESCRIPTION
I made this changes to enable asynchronous CSS loading as Google recommends.
Google PageSpeed Insights is happy with this. It rise TS`s clear site pages rank to GOOD. But we do have lazy loading with essential pause before formatting appears and glitches with some plugins. So, site appears without styling even on PageSpeed's screen-shot.
Maybe we can add this code as options? Because sites rank in Google search results do depends on page speed.

Also, maybe we should move	`gpOutput::GetHead()`; to page bottom in default theme? HTML5 allows such placement of `<meta>`, `<link>` and same tags from `<head>`, and PageSpeed immediately rises page`s rank.