### PR TITLE
Image edit dialogue

### DIFF
--- a/include/css/inline_image.css
+++ b/include/css/inline_image.css
@@ -345,7 +345,6 @@
 
 body #gp_size_options td,
 body #gp_current_image td{
-	text-align:right;
 	vertical-align:middle;
 	padding:5px 3px;
 	font-size:11px;

--- a/include/tool/Editing.php
+++ b/include/tool/Editing.php
@@ -1267,7 +1267,8 @@ namespace gp\tool{
 			echo '<tr><td>'.$langmessage['Left'].'</td><td><input type="text" name="left" class="ck_input" value="0"/></td>';
 			echo '<td>'.$langmessage['Top'].'</td><td><input type="text" name="top" class="ck_input" value="0"/></td>';
 			echo '</tr>';
-			echo '<tr><td colspan="2">'.$langmessage['Alternative Text'].'</td><td colspan="2"><input type="text" name="alt" style="width:70px; text-align:left;" class="ck_input" value=""/></td></tr>';
+			echo '<tr><td colspan="4">'.$langmessage['Alternative Text'].'</td></tr>';
+			echo '<tr><td colspan="4"><input type="text" name="alt" style="width:140px; text-align:left;" class="ck_input" value=""/></td></tr>';
 			echo '<tr><td><a data-cmd="deafult_sizes" class="ckeditor_control ck_reset_size" title="'.$langmessage['Theme_default_sizes'].'">&#10226;</a></td></tr>';
 			echo '</table>';
 			echo '</div>';


### PR DESCRIPTION
Maybe this layout is more beautiful? At least we have more space for alt attribute.

![image](https://user-images.githubusercontent.com/14929385/41995218-9eb9bf5c-7a59-11e8-80ec-eb5ddad7c2d1.png)
