### PR TITLE
Fix non-static method calling

### DIFF
--- a/include/special/Search.php
+++ b/include/special/Search.php
@@ -91,7 +91,7 @@ class Search extends \gp\special\Base{
 		echo '</div>';
 	}
 
-	public function Gadget(){
+	public static function Gadget(){
 
 		$query = '';
 		if( isset($_GET['q']) ){


### PR DESCRIPTION
Fix Deprecated: non-static method gp\special\Search::Gadget() should not be called statically