### PR TITLE
Update admin_finder.scss

### DIFF
--- a/include/css/admin_finder.scss
+++ b/include/css/admin_finder.scss
@@ -99,3 +99,12 @@ body,
 #admincontent_inner .elfinder-button-search input[type="text"]{
 	width: 100%;
 }
+
+/**
+ * Make search input float over menu bar on expand
+ * 
+ */
+#gp_admin_html #elfinder .elfinder-button-search.ui-state-active{
+    z-index: 10;
+    margin-left: -150px;	
+}


### PR DESCRIPTION
I added a few lines to force Search input float over elFinder menu while it expands. This stops button rearrangement.