### PR TITLE
Update inline_edit.css

### DIFF
--- a/include/css/inline_edit.css
+++ b/include/css/inline_edit.css
@@ -343,3 +343,16 @@ html{
 #ckeditor_wrap select.SelectGalleryStyle::-ms-expand { 
 	display:none; 
 	}
+
+
+/**
+ * Codemirror for ckEditor plugin style
+ */
+.searchCodeButton span, 
+.autoFormat span, 
+.CommentSelectedRange span, 
+.UncommentSelectedRange span {
+	margin: 3px!important;
+	min-width: unset!important;
+	background-position: center!important;	
+}


### PR DESCRIPTION
Very rude fix for codeMirror plugin's buttons.
I gave up to find a more glorious way.