### PR TITLE
elFinder: prevent scrollbar when minimize window

### DIFF
--- a/include/css/admin_finder.scss
+++ b/include/css/admin_finder.scss
@@ -24,6 +24,7 @@ body,
 	height: 100% !important;
 	border: 0 none !important;
 	border-radius: 0 !important;
+	overflow: hidden;
 	.elfinder-button,
 	.elfinder-cwd,
 	.elfinder-cwd * {


### PR DESCRIPTION
This "overflow: hidden;" prevent scrolling inside #elfinder. Thus, we can escape ugly jitter during window minimization.

On the other hand, we lose the ability  to catch window moved out from the screen.
But, the current realization of window positioning and #elfinder sizing is very ugly anyway. You can play with windows positions in elFinder and see it.

[Related issue ](https://github.com/Typesetter/Typesetter/issues/375)