### PR TITLE
elFinder: extend too narrowed toolbar

### DIFF
--- a/include/css/admin_finder.scss
+++ b/include/css/admin_finder.scss
@@ -58,6 +58,7 @@ body,
 	}
 	.elfinder-toolbar {
 		background: #ededed;
+		padding: 5px 0;
 	}
 	.elfinder-statusbar {
 		background: #333;


### PR DESCRIPTION
This removes horizontal padding that make buttons in two row on my 4x3 screen