### PR TITLE
elFinder: make place for icons in context menu bigger

### DIFF
--- a/include/css/admin_finder.scss
+++ b/include/css/admin_finder.scss
@@ -94,6 +94,7 @@ body,
 		width: 100% !important;
 	}
 	
+	.elfinder-contextmenu-extra-icon,
 	.elfinder-contextmenu-icon{
 		width: 20px;
 		height: 20px;

--- a/include/css/admin_finder.scss
+++ b/include/css/admin_finder.scss
@@ -93,6 +93,11 @@ body,
 	.elfinder-file-edit {
 		width: 100% !important;
 	}
+	
+	.elfinder-contextmenu-icon{
+		width: 20px;
+		height: 20px;
+    }
 }
 
 /**


### PR DESCRIPTION
Maybe this has already been fixed by Juergen, or maybe the problem is at me only. But icons in context menu are too small and cut