### PR TITLE
elFinder: fix for file names overlapping

### DIFF
--- a/include/css/admin_finder.scss
+++ b/include/css/admin_finder.scss
@@ -72,3 +72,15 @@ body,
 		width: auto;
 	}
 }
+
+/**
+ * fix for long file names overlapping buttons in preview window header
+ */
+.elfinder-quicklook-title {
+	max-width: 100%;
+	text-overflow: ellipsis;
+}
+
+.elfinder-quicklook-titlebar {
+	padding: 0 40px;
+}


### PR DESCRIPTION
Fix for long file names overlapping buttons in preview window header

And, sorry for elFinder again...

before
![image](https://user-images.githubusercontent.com/14929385/71327100-f47eb000-250c-11ea-92e0-722ed17382a1.png)

after
![image](https://user-images.githubusercontent.com/14929385/71327109-09f3da00-250d-11ea-8926-43580eff0b4f.png)
