### PR TITLE
elFinder: Improved allowed/denied file extensions check

### DIFF
--- a/include/admin/Content/Uploaded.php
+++ b/include/admin/Content/Uploaded.php
@@ -641,8 +641,6 @@ namespace gp\admin\Content{
 		 *
 		 */
 		public static function AllowedExtension( &$file , $fix = true ){
-			global $upload_extensions_allow, $upload_extensions_deny, $config;
-			static $allowed_types = false;
 
 			$file = \gp\tool\Files::NoNull($file);
 
@@ -657,7 +655,29 @@ namespace gp\admin\Content{
 			}
 
 
-			//build list of allowed extensions once
+
+			//make sure the extension is allowed
+			$file_type = array_pop($parts);
+			if( !in_array( strtolower($file_type), self::AllowedExtensions() ) ){
+				return false;
+			}
+
+			if( $fix ){
+				return implode('_',$parts).'.'.$file_type;
+			}else{
+				return implode('.',$parts).'.'.$file_type;
+			}
+		}
+
+
+		/**
+		 * Build a list of allowed file extensions
+		 * 
+		 */
+		public static function AllowedExtensions(){
+			global $upload_extensions_allow, $upload_extensions_deny, $config;
+			static $allowed_types = false;
+
 			if( !$allowed_types ){
 
 				if( is_string($upload_extensions_deny) && strtolower($upload_extensions_deny) === 'all' ){
@@ -688,20 +708,7 @@ namespace gp\admin\Content{
 				}
 			}
 
-			$allowed_types = \gp\tool\Plugins::Filter('AllowedTypes',array($allowed_types));
-
-
-			//make sure the extension is allowed
-			$file_type = array_pop($parts);
-			if( !in_array( strtolower($file_type), $allowed_types ) ){
-				return false;
-			}
-
-			if( $fix ){
-				return implode('_',$parts).'.'.$file_type;
-			}else{
-				return implode('.',$parts).'.'.$file_type;
-			}
+			return \gp\tool\Plugins::Filter('AllowedTypes',array($allowed_types));
 		}
 
 

--- a/include/thirdparty/elFinder/connector.php
+++ b/include/thirdparty/elFinder/connector.php
@@ -133,16 +133,6 @@ function upload_check($cmd, $args){
 	return true;
 }
 
-function rename_check($cmd, $args){
-	if( gp_restrict_uploads && !\gp\admin\Content\Uploaded::AllowedExtension($args['name']) ){
-		return array(
-			'preventexec'	=> true,
-			'results'		=> array('error' => 'errUploadMime')
-		);
-	}
-	return true;
-}
-
 // Documentation for connector options:
 // https://github.com/Studio-42/elFinder/wiki/Connector-configuration-options
 $opts = array(
@@ -164,7 +154,7 @@ $opts = array(
 			//'uploadMaxSize'		=>'55M',
 			'attributes'		=> array(
 				array(
-					'pattern' => '/\.ph(p([3-7]?|-?s)|t(ml)?|ar)$/i',
+					'pattern' => gp_restrict_uploads ? '/\.(?!'.join('|', \gp\admin\Content\Uploaded::AllowedExtensions()).')\w+$/i' : null,
 					'write'  => false,
 				)
 			),
@@ -185,7 +175,6 @@ $opts = array(
 	'bind' => array(
 		'duplicate upload rename rm paste resize' => array('\gp\admin\Content\Uploaded', 'FinderChange'), //drag+drop = cut+paste
 		'upload.pre'		=> array('upload_check'),
-		'rename.pre'		=> array('rename_check'),
 	)
 );
 


### PR DESCRIPTION
Now all file extensions, even files extracted from archives, will be checked.

I also tried to [check files by MIME types](https://github.com/Sestowner/Typesetter/commit/7eb895ae85eff9f713c855cf1da6ea28638b2be0), but I find this changes better.