### PR TITLE
Re: Prevent AJAX replacement effects in Notification box links

### DIFF
--- a/addons/Multi Site/SetupSite.php
+++ b/addons/Multi Site/SetupSite.php
@@ -1731,7 +1731,7 @@ class SetupSite{
 
 		$content = ob_get_clean();
 
-		$page->ajaxReplace[] = array('admin_box_data','',$content);
+		$page->ajaxReplace[] = array('gpabox','',$content);
 	}
 
 	public function RemoveDir(){

--- a/include/Page/Rename.php
+++ b/include/Page/Rename.php
@@ -161,7 +161,7 @@ namespace gp\Page{
 
 
 			$array = array();
-			$array[0] = 'admin_box_data';
+			$array[0] = 'gpabox';
 			$array[1] = '';
 			$array[2] = $content;
 			$page->ajaxReplace[] = $array;

--- a/include/admin/Notifications.php
+++ b/include/admin/Notifications.php
@@ -46,7 +46,7 @@ namespace gp\admin{
 								'title'		=> $langmessage['Previous'],
 								'class'		=> 'gpbutton',
 								'style'		=> 'margin-right:0.5em;',
-								'data-cmd'	=> 'gprabox',
+								'data-cmd'	=> 'gpabox',
 							)
 						);
 					}elseif( !$next_notification_link ){
@@ -57,7 +57,7 @@ namespace gp\admin{
 							array(
 								'title'		=> $langmessage['Next'],
 								'class'		=> 'gpbutton',
-								'data-cmd'	=> 'gprabox',
+								'data-cmd'	=> 'gpabox',
 							)
 						);
 					}
@@ -97,7 +97,7 @@ namespace gp\admin{
 								array(
 									'title'		=> ($muted ? $langmessage['Show'] : $langmessage['Hide']),
 									'class'		=> 'toggle-notification',
-									'data-cmd'	=> 'gprabox',
+									'data-cmd'	=> 'gpabox',
 								)
 							);
 

--- a/include/js/admin.js
+++ b/include/js/admin.js
@@ -684,19 +684,11 @@ $gp.links.gpabox = function(evt){
 	evt.preventDefault();
 	$gp.loading();
 	var href = $gp.jPrep(this.href)+'&gpx_content=gpabox';
-	$.getJSON(href,$gp.Response);
-};
+	var this_context = this;
+	$.getJSON(href,function(data,textStatus,jqXHR){
+		$gp.Response.call(this_context,data,textStatus,jqXHR);
+	});
 
-
-/**
- * Almost same as gpabox but used to replace an already open modal box with a new one,
- * without showing the overlay and fadeIn effect.
- * Should only be used for links inside a modal box to replace the same box
- */
-$gp.links.gprabox = function(evt){
-	evt.preventDefault();
-	var href = $gp.jPrep(this.href)+'&gpx_content=gprabox';
-	$.getJSON(href, $gp.Response);
 };
 
 

--- a/include/js/main.js
+++ b/include/js/main.js
@@ -228,12 +228,13 @@ var $gp = {
 					CallFunc( obj.SELECTOR, 'html', obj.CONTENT);
 				break;
 
-				case 'admin_box_data':
-					$gp.AdminBoxC(obj.CONTENT);
-				break;
-
-				case 'admin_box_replace':
-					$gp.AdminBoxC(obj.CONTENT, {replaceBox : true});
+				case 'gpabox':
+				case 'admin_box_data': // @deprecated 5.2
+					var opts = {};
+					if( $(this_context).closest('#gp_admin_box') ){ // replace the content of the currently open admin box if the link the user clicked on was in the admin box
+						opts.replaceBox = true;
+					}
+					$gp.AdminBoxC(obj.CONTENT,opts);
 				break;
 
 				case 'messages':

--- a/include/tool.php
+++ b/include/tool.php
@@ -1796,7 +1796,7 @@ namespace gp{
 
 		public static function AjaxWarning(){
 			global $page,$langmessage;
-			$page->ajaxReplace[] = array('admin_box_data', '', $langmessage['OOPS_Start_over']);
+			$page->ajaxReplace[] = array('gpabox', '', $langmessage['OOPS_Start_over']);
 		}
 
 

--- a/include/tool/Output/Ajax.php
+++ b/include/tool/Output/Ajax.php
@@ -84,14 +84,8 @@ namespace gp\tool\Output{
 
 			//output content
 			if( !empty($_REQUEST['gpx_content']) ){
-				switch($_REQUEST['gpx_content']){
-					case 'gpabox':
-						self::JsonDo('admin_box_data', '', $page->contentBuffer);
-					break;
-					case 'gprabox':
-						self::JsonDo('admin_box_replace', '', $page->contentBuffer);
-					break;
-				}
+				self::JsonDo($_REQUEST['gpx_content'], '', $page->contentBuffer);
+				
 			}elseif( in_array('#gpx_content', $page->ajaxReplace) ){
 				$replace_id = '#gpx_content';
 


### PR DESCRIPTION
This is a different approach to the same problem fixed with the addition of gprabox in [this commit](31c39ef6f1e7604cd008f4f016787b1552fdf516).

This will add the replaceBox=true option to the AdminBoxC() call whenever a gpabox link is clicked within an admin_box.