### PR TITLE
elFinder: preparation for feature releases

### DIFF
--- a/include/thirdparty/elFinder/main.custom.js
+++ b/include/thirdparty/elFinder/main.custom.js
@@ -168,6 +168,7 @@ define('jquery-ui', [], function() {});
 
 				},
 				height:'100%'
+				,dialogContained : true
 				,cssAutoLoad : [ '/themes/material/css/theme-custom.css' ]
 				,getFileCallback:function(file, finder){
 


### PR DESCRIPTION
This is the right way to set dialogContained : true that was done before directly in elfinder.min.js.

As we discussed, I made a [PR](https://github.com/Studio-42/elFinder/pull/3072) to elFinder with my fix. They did not merge it, but made a big [fix](https://github.com/Studio-42/elFinder/commit/9ae38ce2023a23d21afc37d43eb09605f9ff3934). Now it is only in nightly builds and still has some problems.

Maybe  elFinder 2.1.52 will be OK, and we will be able to include it in the TS. So, I decided to prepare for this moment and move our setting for dialog movement limitation from elfinder.min.js to a more proper place.

UPD
I checked this fix with elFinder updated to last nightly build. All work good 