### PR TITLE
Make the outline of a hovered section clearer

### DIFF
--- a/include/css/manage_sections.css
+++ b/include/css/manage_sections.css
@@ -37,7 +37,7 @@
 }
 
 #section_sorting li.section-sorting-highlight{
-	outline:1px solid #bbb;
+	outline:1px solid #333;
 	outline-offset:-1px;
 }
 

--- a/include/css/manage_sections_compact.css
+++ b/include/css/manage_sections_compact.css
@@ -37,7 +37,7 @@
 }
 
 #section_sorting li.section-sorting-highlight{
-	outline:1px solid #bbb;
+	outline:1px solid #333;
 	outline-offset:-1px;
 }
 


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/14929385/71643695-381fa980-2cc5-11ea-8fd3-6796b5cde4ce.png)

After
![image](https://user-images.githubusercontent.com/14929385/71643704-5be2ef80-2cc5-11ea-881c-1c79e4177f94.png)

Am I the only one who can not find hovered section in the list in one glance? :)