### PR TITLE
Do we need this $.colorbox.remove()?

### DIFF
--- a/include/js/main.js
+++ b/include/js/main.js
@@ -343,7 +343,7 @@ var $gp = {
 				selector = 'a[rel='+selector+'],a.'+selector;
 			}
 
-			$.colorbox.remove();
+/*			$.colorbox.remove(); */
 			$(selector).colorbox(
 				$gp.cboxSettings({
 					resize : true ,


### PR DESCRIPTION
I found that this line kill all the other colorboxes on the page after I click on the gallery image.
Is it really necessary?