### PR TITLE
Revision history redesign

### DIFF
--- a/include/Base.php
+++ b/include/Base.php
@@ -7,7 +7,9 @@ defined('is_running') or die('Not an entry point...');
 abstract class Base{
 
 	//executable commands
-	protected $cmds				= array();
+	protected $cmds				= [];
+	protected $cmds_post		= [];
+
 
 
 	/**
@@ -16,19 +18,36 @@ abstract class Base{
 	 */
 	public function RunCommands($cmd){
 
+		// POST commands
+		if( $_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['cmd']) && $_POST['cmd'] === $cmd ){
+			if( $this->_RunCommands($cmd, $this->cmds_post) ){
+				return;
+			}
+		}
+
+		// All others
+		if( $this->_RunCommands($cmd, $this->cmds) ){
+			return;
+		}
+
+
+		$this->DefaultDisplay();
+	}
+
+	private function _RunCommands($cmd, $cmds){
+
 		if( !is_string($cmd) ){
 			$cmd = '';
 		}
 
-		$this->cmds	= array_change_key_case($this->cmds, CASE_LOWER);
+		$cmds		= array_change_key_case($cmds, CASE_LOWER);
 		$cmd		= strtolower($cmd);
 
-		if( !isset($this->cmds[$cmd]) ){
-			$this->DefaultDisplay();
-			return;
+		if( !isset($cmds[$cmd]) ){
+			return false;
 		}
 
-		$cmds = (array)$this->cmds[$cmd];
+		$cmds = (array)$cmds[$cmd];
 		array_unshift($cmds, $cmd);
 
 		foreach($cmds as $cmd){
@@ -39,7 +58,9 @@ abstract class Base{
 			}
 		}
 
+		return true;
 	}
+
 
 	/**
 	 * Set the executable commands

--- a/include/Page/Edit.php
+++ b/include/Page/Edit.php
@@ -97,7 +97,7 @@ class Edit extends \gp\Page{
 
 			$this->cmds['ViewRevision']				= '';
 			$this->cmds['UseRevision']				= 'DefaultDisplay';
-			$this->cmds['ViewHistory']				= '';
+			//$this->cmds['ViewHistory']				= '';
 			$this->cmds['ViewCurrent']				= '';
 			$this->cmds['PublishDraft']				= 'DefaultDisplay';
 
@@ -1465,6 +1465,7 @@ class Edit extends \gp\Page{
 		$time							=& $_REQUEST['time'];
 		$file_sections					= $this->GetRevision($time);
 
+		$this->head_js[]				= '/include/js/admin/revision.js';
 
 		if( $file_sections === false ){
 			$this->DefaultDisplay();
@@ -1476,6 +1477,25 @@ class Edit extends \gp\Page{
 		echo \gp\tool\Output\Sections::Render($file_sections, $this->title, \gp\tool\Files::$last_stats);
 	}
 
+
+	/**
+	 * View the current public facing version of the file
+	 *
+	 */
+	public function ViewCurrent(){
+
+		\gp\admin\Tools::$show_toolbar		= false;
+		$this->head_js[]					= '/include/js/admin/revision.js';
+
+		if( !$this->draft_exists ){
+			$this->DefaultDisplay();
+			return;
+		}
+
+		$file_sections			= \gp\tool\Files::Get($this->file, 'file_sections');
+		$this->revision			= $this->fileModTime;
+		echo \gp\tool\Output\Sections::Render($file_sections, $this->title, $this->file_stats);
+	}
 
 
 	/**
@@ -1528,26 +1548,6 @@ class Edit extends \gp\Page{
 		}
 
 		return $file_sections;
-	}
-
-
-
-	/**
-	 * View the current public facing version of the file
-	 *
-	 */
-	public function ViewCurrent(){
-
-		\gp\admin\Tools::$show_toolbar		= false;
-
-		if( !$this->draft_exists ){
-			$this->DefaultDisplay();
-			return;
-		}
-
-		$file_sections			= \gp\tool\Files::Get($this->file, 'file_sections');
-		$this->revision			= $this->fileModTime;
-		echo \gp\tool\Output\Sections::Render($file_sections, $this->title, $this->file_stats);
 	}
 
 

--- a/include/Page/Edit.php
+++ b/include/Page/Edit.php
@@ -95,8 +95,6 @@ class Edit extends \gp\Page{
 			$this->cmds['AddFromClipboard']			= '';
 
 			$this->cmds['ViewRevision']				= '';
-			$this->cmds['UseRevision']				= 'DefaultDisplay';
-			//$this->cmds['ViewHistory']				= '';
 			$this->cmds['ViewCurrent']				= '';
 			$this->cmds['PublishDraft']				= 'DefaultDisplay';
 
@@ -172,7 +170,7 @@ class Edit extends \gp\Page{
 		$admin_links[]	= \gp\tool::Link(
 			'/Admin/Revisions/'.$this->gp_index,
 			'<i class="fa fa-history"></i> ' . $langmessage['Revision History'],
-			'cmd=ViewHistory',
+			'',
 			array(
 				'title'		=> $langmessage['Revision History'],
 				'class'		=> 'admin-link admin-link-revision-history',
@@ -315,39 +313,6 @@ class Edit extends \gp\Page{
 		}
 		return \gp\tool::Link('Admin/Menu/Ajax', $label, $q, $attrs);
 	}
-
-
-
-	/*
-	 * Return admin links when a revision is being displayed
-	 *
-	protected function RevisionLinks(){
-		global $langmessage;
-
-		$admin_links		= array();
-
-
-		// restore this version
-		if( $this->revision == $this->fileModTime ){
-			$date	= $langmessage['Current Page'];
-		}else{
-			$date	= \gp\tool::date($langmessage['strftime_datetime'],$this->revision);
-		}
-
-		$admin_links[] = \gp\tool::Link(
-			$this->title,
-			'<i class="fa fa-save"></i> ' . $langmessage['Restore this revision'] . ' (' . $date . ')',
-			'cmd=UseRevision&time=' . $this->revision,
-			array(
-				'data-cmd'	=> 'cnreq',
-				'class'		=> 'msg_publish_draft admin-link admin-link-publish-draft'
-			)
-		);
-
-		return $admin_links;
-	}
-	*/
-
 
 
 	/**
@@ -1367,35 +1332,6 @@ class Edit extends \gp\Page{
 	}
 
 
-
-	/**
-	 * Get info about a backup from the filename
-	 *
-	 */
-	public function BackupInfo($file){
-
-		$info = array();
-
-		//remove .gze
-		if( strpos($file,'.gze') === (strlen($file)-4) ){
-			$file = substr($file, 0, -4);
-		}
-
-		$name				= basename($file);
-		$parts				= explode('.', $name, 3);
-
-		$info['time']		= array_shift($parts);
-		$info['size']		= array_shift($parts);
-		$info['username']	= '';
-
-		if( count($parts) ){
-			$info['username'] = array_shift($parts);
-		}
-
-		return $info;
-	}
-
-
 	/**
 	 * Display the contents of a past revision
 	 *
@@ -1403,8 +1339,8 @@ class Edit extends \gp\Page{
 	protected function ViewRevision(){
 
 		\gp\admin\Tools::$show_toolbar	= false;
-		$time							=& $_REQUEST['time'];
-		$file_sections					= $this->GetRevision($time);
+		$revision						=& $_REQUEST['revision'];
+		$file_sections					= $this->GetRevision($revision);
 
 		$this->head_js[]				= '/include/js/admin/revision.js';
 
@@ -1434,25 +1370,6 @@ class Edit extends \gp\Page{
 
 		$file_sections			= \gp\tool\Files::Get($this->file, 'file_sections');
 		echo \gp\tool\Output\Sections::Render($file_sections, $this->title, $this->file_stats);
-	}
-
-
-	/**
-	 * Revert the file data to a previous revision
-	 *
-	 */
-	protected function UseRevision(){
-
-		$time			=& $_REQUEST['time'];
-		$file_sections	= $this->GetRevision($time);
-
-		if( $file_sections === false ){
-			return false;
-		}
-
-		$this->file_sections = $file_sections;
-		$this->SaveThis();
-
 	}
 
 
@@ -1645,7 +1562,7 @@ class Edit extends \gp\Page{
 				echo \gp\tool::Link(
 						'/Admin/Revisions/'.$this->gp_index,
 						$langmessage['Revision History'],
-						'cmd=ViewHistory'
+						''
 					);
 				echo '<span class="gp_separator"></span>';
 				echo \gp\tool::Link('Admin/Menu', $langmessage['file_manager']);

--- a/include/Page/Edit.php
+++ b/include/Page/Edit.php
@@ -8,7 +8,6 @@ class Edit extends \gp\Page{
 
 	protected $draft_file;
 	protected $draft_exists = false;
-	protected $revision;
 
 	protected $permission_edit;
 	protected $permission_menu;
@@ -167,27 +166,8 @@ class Edit extends \gp\Page{
 	public function AdminLinks(){
 		global $langmessage;
 
-		//viewing revision
-		if( isset($this->revision) ){
-			return $this->RevisionLinks();
-		}
 
 		$admin_links		= array();
-
-		//history
-		$backup_files		= $this->BackupFiles();
-		if( count($backup_files) ){
-			$times			= array_keys($backup_files);
-			$admin_links[]	= \gp\tool::Link(
-				$this->title,
-				'<i class="fa fa-backward"></i> ' . $langmessage['Previous'],
-				'cmd=ViewRevision&time=' . array_pop($times),
-				array(
-					'class'		=> 'admin-link admin-link-previous-revision',
-					'data-cmd'	=> 'cnreq',
-				)
-			);
-		}
 
 		$admin_links[]	= \gp\tool::Link(
 			'/Admin/Revisions/'.$this->gp_index,
@@ -338,54 +318,14 @@ class Edit extends \gp\Page{
 
 
 
-	/**
+	/*
 	 * Return admin links when a revision is being displayed
 	 *
-	 */
 	protected function RevisionLinks(){
 		global $langmessage;
 
 		$admin_links		= array();
 
-		//previous && next revision
-		$files			= $this->BackupFiles();
-		$times			= array_keys($files);
-		$key_current	= array_search($this->revision, $times);
-
-		if( $key_current !== false ){
-			if( isset($times[$key_current-1]) ){
-				$admin_links[]	= \gp\tool::Link(
-					$this->title,
-					'<i class="fa fa-backward"></i> ' . $langmessage['Previous'],
-					'cmd=ViewRevision&time=' . $times[$key_current - 1],
-					array('data-cmd'=>'cnreq')
-				);
-			}
-
-			if( isset($times[$key_current+1]) ){
-				$admin_links[]	= \gp\tool::Link(
-					$this->title,
-					'<i class="fa fa-forward"></i> ' . $langmessage['Next'],
-					'cmd=ViewRevision&time=' . $times[$key_current + 1],
-					array('data-cmd'=>'cnreq')
-				);
-			}else{
-				$admin_links[]	= \gp\tool::Link(
-					$this->title,
-					'<i class="fa fa-forward"></i> ' . $langmessage['Working Draft']
-				);
-			}
-
-		}
-
-		$admin_links[] = \gp\tool::Link(
-			'/Admin/Revisions/'.$this->gp_index,
-			'<i class="fa fa-history"></i> ' . $langmessage['Revision History'],
-			'cmd=ViewHistory',
-			array(
-				'title'		=> $langmessage['Revision History'],
-			)
-		);
 
 		// restore this version
 		if( $this->revision == $this->fileModTime ){
@@ -406,6 +346,7 @@ class Edit extends \gp\Page{
 
 		return $admin_links;
 	}
+	*/
 
 
 
@@ -1473,7 +1414,6 @@ class Edit extends \gp\Page{
 		}
 
 
-		$this->revision			= $time;
 		echo \gp\tool\Output\Sections::Render($file_sections, $this->title, \gp\tool\Files::$last_stats);
 	}
 
@@ -1493,7 +1433,6 @@ class Edit extends \gp\Page{
 		}
 
 		$file_sections			= \gp\tool\Files::Get($this->file, 'file_sections');
-		$this->revision			= $this->fileModTime;
 		echo \gp\tool\Output\Sections::Render($file_sections, $this->title, $this->file_stats);
 	}
 

--- a/include/admin/Content/Revisions.php
+++ b/include/admin/Content/Revisions.php
@@ -2,7 +2,12 @@
 
 namespace gp\admin\Content;
 
-//class Revisions extends \gp\special\Base{
+/**
+ * ToDo
+ * Restore version link see RevisionLinks()
+ *
+ */
+
 class Revisions extends \gp\Page\Edit{
 
 

--- a/include/admin/Content/Revisions.php
+++ b/include/admin/Content/Revisions.php
@@ -53,8 +53,8 @@ class Revisions extends \gp\Page\Edit{
 		$url		= \gp\tool::GetUrl($this->title,'cmd=ViewCurrent');
 		$toolbar	= '<br/><h2>' . $langmessage['Revision History'] . '</h2>';
 		$toolbar	.= \gp\tool::Link_Page($this->title);
-		$toolbar	.= ' &nbsp; <a data-cmd="PreviousRevision"><i class="fa fa-backward"></i> ' . $langmessage['Previous'] . '</a>';
-		$toolbar	.= ' &nbsp; <a data-cmd="NextRevision"><i class="fa fa-forward"></i> ' . $langmessage['Next'] . '</a>';
+		$toolbar	.= ' &nbsp; <a data-cmd="PreviousRevision"><i class="fa fa-backward fa-fw"></i> ' . $langmessage['Previous'] . '</a>';
+		$toolbar	.= ' &nbsp; <a data-cmd="NextRevision">' . $langmessage['Next'] . ' <i class="fa fa-forward fa-fw"></i></a>';
 
 
 

--- a/include/admin/Content/Revisions.php
+++ b/include/admin/Content/Revisions.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace gp\admin\Content;
+
+//class Revisions extends \gp\special\Base{
+class Revisions extends \gp\Page\Edit{
+
+
+	public $cmds = [
+						'DeleteRevision' => 'DefaultDisplay'
+					];
+
+
+	public function __construct($args){
+		global $gp_index;
+
+		//parent::__construct($args);
+
+		if( empty($args['path_parts']) ){
+			$url = \gp\tool::GetUrl('Admin');
+			\gp\tool::Redirect($url);
+		}
+
+		$index		= $args['path_parts'][0];
+		$title		= array_search($index, $gp_index);
+
+		if( $title === false ){
+			$url = \gp\tool::GetUrl('Admin');
+			\gp\tool::Redirect($url);
+		}
+
+		parent::__construct($title,'');
+
+	}
+
+	public function RunScript(){
+
+		$this->SetVars();
+		$this->GetFile();
+
+		$cmd = \gp\tool::GetCommand();
+		$this->RunCommands($cmd);
+	}
+
+
+	public function DefaultDisplay(){
+		global $page;
+
+
+		//show site in iframe
+		$url		= \gp\tool::GetUrl($this->title,'cmd=ViewCurrent');
+		$toolbar	= \gp\tool::Link_Page($this->title);
+
+
+		ob_start();
+		$this->ViewHistory();
+		$content = ob_get_clean();
+
+
+		\gp\admin\Tools\Iframe::Output( $page, $url, $toolbar, $content);
+	}
+
+
+	/**
+	 * Display the revision history of the current file
+	 *
+	 */
+	public function ViewHistory(){
+		global $langmessage, $config;
+
+		$files		= $this->BackupFiles();
+		$rows		= array();
+
+		//working draft
+		if( $this->draft_exists ){
+			$draft_file = \gp\tool\Files::FilePath($this->draft_file);
+			$size = filesize($draft_file);
+			$time = $this->file_stats['modified'];
+			$rows[$time] = $this->HistoryRow($time, $size, $this->file_stats['username'], 'draft');
+		}
+
+		foreach($files as $time => $file){
+			$info = $this->BackupInfo($file);
+			$rows[$time] = $this->HistoryRow($info['time'], $info['size'], $info['username']);
+		}
+
+		// current page
+		// this will overwrite one of the history entries if there is a draft
+		$page_file = \gp\tool\Files::FilePath($this->file);
+		$rows[$this->fileModTime] = $this->HistoryRow($this->fileModTime, filesize($page_file), $this->file_stats['username'], 'current');
+
+		echo '<br/>';
+		echo '<h2>' . $langmessage['Revision History'] . '</h2>';
+		echo '<table class="bordered full_width striped"><tr>';
+		echo '<th>' . $langmessage['Modified'] . '</th>';
+		echo '<th>' . $langmessage['File Size'] . '</th>';
+		echo '<th>' . $langmessage['username'] . '</th>';
+		echo '<th>&nbsp;</th>';
+		echo '</tr><tbody>';
+
+		krsort($rows);
+		echo implode('', $rows);
+
+		echo '</tbody>';
+		echo '</table>';
+
+		echo '<p>' . $langmessage['history_limit'] . ': ' . $config['history_limit'] . '</p>';
+	}
+
+
+
+	/**
+	 * Return content for history row
+	 *
+	 */
+	protected function HistoryRow($time, $size, $username, $which='history'){
+		global $langmessage;
+
+		ob_start();
+		$date = \gp\tool::date($langmessage['strftime_datetime'], $time);
+		echo '<tr><td title="' . htmlspecialchars($date) . '">';
+		switch($which){
+			case 'current':
+				echo '<b>' . $langmessage['Current Page'] . '</b><br/>';
+				break;
+
+			case 'draft':
+				echo '<b>' . $langmessage['Working Draft'] . '</b><br/>';
+				break;
+		}
+
+		$elapsed = \gp\admin\Tools::Elapsed(time() - $time);
+		echo sprintf($langmessage['_ago'], $elapsed);
+		echo '</td><td>';
+		if( $size && is_numeric($size) ){
+			echo \gp\admin\Tools::FormatBytes($size);
+		}
+		echo '</td><td>';
+		if( !empty($username) ){
+			echo $username;
+		}
+		echo '</td><td>';
+
+		switch($which){
+			case 'current':
+				echo \gp\tool::Link(
+					$this->title,
+					$langmessage['View'],
+					'cmd=ViewCurrent',
+					array(
+						'target'	=> 'gp_layout_iframe',
+					)
+				);
+				break;
+
+			case 'draft':
+				echo \gp\tool::Link($this->title, $langmessage['View'],'cmd=ViewRevision&time=draft',['target'=>'gp_layout_iframe']);
+				echo ' &nbsp; ' . \gp\tool::Link(
+					$this->title,
+					$langmessage['Publish Draft'],
+					'cmd=PublishDraft',
+					array(
+						'data-cmd' => 'cnreq',
+					)
+				);
+				break;
+
+			case 'history':
+				echo \gp\tool::Link(
+					$this->title,
+					$langmessage['View'],
+					'cmd=ViewRevision&time=' . $time,
+					array(
+						'target'	=> 'gp_layout_iframe',
+					)
+				);
+				echo ' &nbsp; ';
+				echo \gp\tool::Link(
+					'/Admin/Revisions/'.$this->gp_index,
+					$langmessage['delete'],
+					'cmd=DeleteRevision&time=' . $time,
+					array(
+						'class'		=> 'gpconfirm',
+					)
+				);
+				break;
+		}
+
+		echo '</td></tr>';
+		return ob_get_clean();
+	}
+
+	/**
+	 * Delete a revision backup
+	 *
+	 */
+	public function DeleteRevision(){
+
+		$full_path	= $this->BackupFile($_REQUEST['time']);
+		if( is_null($full_path) ){
+			return false;
+		}
+		unlink($full_path);
+	}
+
+
+
+}

--- a/include/admin/Content/Revisions.php
+++ b/include/admin/Content/Revisions.php
@@ -2,18 +2,14 @@
 
 namespace gp\admin\Content;
 
-/**
- * ToDo
- * Restore version link see RevisionLinks()
- *
- */
 
 class Revisions extends \gp\Page\Edit{
 
 
-	public $cmds = [
-						'DeleteRevision' => 'DefaultDisplay'
-					];
+	public $cmds_post = [
+							'DeleteRevision'	=> 'DefaultDisplay',
+							'UseRevision'		=> 'DefaultDisplay',
+						];
 
 
 	public function __construct($args){
@@ -55,7 +51,7 @@ class Revisions extends \gp\Page\Edit{
 		$page->head_js[]				= '/include/js/admin/revisions.js';
 
 		//show site in iframe
-		$url		= \gp\tool::GetUrl($this->title,'cmd=ViewCurrent');
+		$url		= \gp\tool::GetUrl($this->title,'cmd=ViewRevision&revision=draft');
 		$toolbar	= '<br/><h2>' . $langmessage['Revision History'] . '</h2>';
 		$toolbar	.= \gp\tool::Link_Page($this->title);
 		$toolbar	.= ' &nbsp; <a data-cmd="PreviousRevision"><i class="fa fa-backward fa-fw"></i> ' . $langmessage['Previous'] . '</a>';
@@ -82,23 +78,30 @@ class Revisions extends \gp\Page\Edit{
 		$files		= $this->BackupFiles();
 		$rows		= array();
 
-		//working draft
-		if( $this->draft_exists ){
-			$draft_file = \gp\tool\Files::FilePath($this->draft_file);
-			$size = filesize($draft_file);
-			$time = $this->file_stats['modified'];
-			$rows[$time] = $this->HistoryRow($time, $size, $this->file_stats['username'], 'draft');
-		}
-
 		foreach($files as $time => $file){
-			$info = $this->BackupInfo($file);
-			$rows[$time] = $this->HistoryRow($info['time'], $info['size'], $info['username']);
+			$info		= $this->BackupInfo($file);
+			$rows[]		= ['time'=>$time,'row'=>$this->HistoryRow($info['time'], $info['size'], $info['username'])];
 		}
 
 		// current page
 		// this will overwrite one of the history entries if there is a draft
-		$page_file = \gp\tool\Files::FilePath($this->file);
-		$rows[$this->fileModTime] = $this->HistoryRow($this->fileModTime, filesize($page_file), $this->file_stats['username'], 'current');
+		$page_file		= \gp\tool\Files::FilePath($this->file);
+		$rows[]			= ['time'=>$this->fileModTime,'row'=>$this->HistoryRow($this->fileModTime, filesize($page_file), $this->file_stats['username'], 'current')];
+
+		usort($rows,function($a,$b){
+			return strnatcmp($b['time'],$a['time']);
+		});
+
+		// working draft
+		// always make it the first row
+		if( $this->draft_exists ){
+			$draft_file		= \gp\tool\Files::FilePath($this->draft_file);
+			$size			= filesize($draft_file);
+			$time			= $this->file_stats['modified'];
+
+			array_unshift($rows,['time'=>$time,'row'=>$this->HistoryRow($time, $size, $this->file_stats['username'], 'draft')]);
+		}
+
 
 		echo '<br/>';
 		echo '<table class="bordered full_width striped hover"><tr>';
@@ -108,8 +111,9 @@ class Revisions extends \gp\Page\Edit{
 		echo '<th>&nbsp;</th>';
 		echo '</tr><tbody id="revision_rows">';
 
-		krsort($rows);
-		echo implode('', $rows);
+		foreach($rows as $row){
+			echo $row['row'];
+		}
 
 		echo '</tbody>';
 		echo '</table>';
@@ -125,6 +129,7 @@ class Revisions extends \gp\Page\Edit{
 	 */
 	protected function HistoryRow($time, $size, $username, $which='history'){
 		global $langmessage;
+		static $i = 1;
 
 		ob_start();
 		$date = \gp\tool::date($langmessage['strftime_datetime'], $time);
@@ -151,27 +156,28 @@ class Revisions extends \gp\Page\Edit{
 		}
 		echo '</td><td>';
 
+
 		switch($which){
 			case 'current':
 				echo \gp\tool::Link(
 					$this->title,
 					$langmessage['View'],
 					'cmd=ViewCurrent',
-					array(
-						'target'	=> 'gp_layout_iframe',
-					)
+					['target' => 'gp_layout_iframe']
 				);
 				break;
 
 			case 'draft':
-				echo \gp\tool::Link($this->title, $langmessage['View'],'cmd=ViewRevision&time=draft',['target'=>'gp_layout_iframe']);
+				echo \gp\tool::Link(
+					$this->title,
+					$langmessage['View'],
+					'cmd=ViewRevision&revision=draft',
+					['target' => 'gp_layout_iframe']
+				);
+
 				echo ' &nbsp; ' . \gp\tool::Link(
 					$this->title,
-					$langmessage['Publish Draft'],
-					'cmd=PublishDraft',
-					array(
-						'data-cmd' => 'cnreq',
-					)
+					$langmessage['edit']
 				);
 				break;
 
@@ -179,18 +185,32 @@ class Revisions extends \gp\Page\Edit{
 				echo \gp\tool::Link(
 					$this->title,
 					$langmessage['View'],
-					'cmd=ViewRevision&time=' . $time,
+					'cmd=ViewRevision&revision=' . $time,
 					array(
 						'target'	=> 'gp_layout_iframe',
 					)
 				);
+
+				echo ' &nbsp; ';
+				echo \gp\tool::Link(
+					'Admin/Revisions/' . $this->gp_index,
+					$langmessage['restore'],
+					'cmd=UseRevision&revision=' . $time,
+					array(
+						'data-cmd'	=> 'post',
+						'class'		=> 'msg_publish_draft admin-link admin-link-publish-draft'
+					)
+				);
+
 				echo ' &nbsp; ';
 				echo \gp\tool::Link(
 					'/Admin/Revisions/'.$this->gp_index,
-					$langmessage['delete'],
-					'cmd=DeleteRevision&time=' . $time,
+					'<i class="fa fa-trash fa-fw"></i>',
+					'cmd=DeleteRevision&revision=' . $time,
 					array(
+						'title'		=> $langmessage['delete'],
 						'class'		=> 'gpconfirm',
+						'data-cmd'	=> 'post',
 					)
 				);
 				break;
@@ -206,13 +226,62 @@ class Revisions extends \gp\Page\Edit{
 	 */
 	public function DeleteRevision(){
 
-		$full_path	= $this->BackupFile($_REQUEST['time']);
+		$full_path	= $this->BackupFile($_REQUEST['revision']);
 		if( is_null($full_path) ){
 			return false;
 		}
 		unlink($full_path);
 	}
 
+	/**
+	 * Revert the file data to a previous revision
+	 *
+	 */
+	protected function UseRevision(){
 
+		$revision			=& $_REQUEST['revision'];
+		$file_sections		= $this->GetRevision($revision);
+
+		if( $file_sections === false ){
+			debug('section not found');
+			return false;
+		}
+
+		debug('savethis');
+
+		$this->file_sections = $file_sections;
+		$this->SaveThis();
+
+		$url = \gp\tool::GetUrl('Admin/Revisions/'.$this->gp_index);
+		\gp\tool::Redirect($url);
+	}
+
+
+	/**
+	 * Get info about a backup from the filename
+	 *
+	 */
+	public function BackupInfo($file){
+
+		$info = array();
+
+		//remove .gze
+		if( strpos($file,'.gze') === (strlen($file)-4) ){
+			$file = substr($file, 0, -4);
+		}
+
+		$name				= basename($file);
+		$parts				= explode('.', $name, 3);
+
+		$info['time']		= array_shift($parts);
+		$info['size']		= array_shift($parts);
+		$info['username']	= '';
+
+		if( count($parts) ){
+			$info['username'] = array_shift($parts);
+		}
+
+		return $info;
+	}
 
 }

--- a/include/admin/Content/Revisions.php
+++ b/include/admin/Content/Revisions.php
@@ -44,12 +44,18 @@ class Revisions extends \gp\Page\Edit{
 
 
 	public function DefaultDisplay(){
-		global $page;
+		global $page, $langmessage;
 
+
+		$page->head_js[]				= '/include/js/admin/revisions.js';
 
 		//show site in iframe
 		$url		= \gp\tool::GetUrl($this->title,'cmd=ViewCurrent');
-		$toolbar	= \gp\tool::Link_Page($this->title);
+		$toolbar	= '<br/><h2>' . $langmessage['Revision History'] . '</h2>';
+		$toolbar	.= \gp\tool::Link_Page($this->title);
+		$toolbar	.= ' &nbsp; <a data-cmd="PreviousRevision"><i class="fa fa-backward"></i> ' . $langmessage['Previous'] . '</a>';
+		$toolbar	.= ' &nbsp; <a data-cmd="NextRevision"><i class="fa fa-forward"></i> ' . $langmessage['Next'] . '</a>';
+
 
 
 		ob_start();
@@ -90,13 +96,12 @@ class Revisions extends \gp\Page\Edit{
 		$rows[$this->fileModTime] = $this->HistoryRow($this->fileModTime, filesize($page_file), $this->file_stats['username'], 'current');
 
 		echo '<br/>';
-		echo '<h2>' . $langmessage['Revision History'] . '</h2>';
-		echo '<table class="bordered full_width striped"><tr>';
+		echo '<table class="bordered full_width striped hover"><tr>';
 		echo '<th>' . $langmessage['Modified'] . '</th>';
 		echo '<th>' . $langmessage['File Size'] . '</th>';
 		echo '<th>' . $langmessage['username'] . '</th>';
 		echo '<th>&nbsp;</th>';
-		echo '</tr><tbody>';
+		echo '</tr><tbody id="revision_rows">';
 
 		krsort($rows);
 		echo implode('', $rows);

--- a/include/admin/Layout/Available.php
+++ b/include/admin/Layout/Available.php
@@ -373,10 +373,11 @@ class Available extends \gp\admin\Layout{
 
 		$_REQUEST += array('gpreq' => 'body'); //force showing only the body as a complete html document
 
-		$this->page->get_theme_css	= false;
-		$this->page->head_js[]		= '/include/js/auto_width.js';
-		$this->page->head_js[]		= '/include/js/theme_content_outer.js';
-		$this->page->css_admin[]	= '/include/css/theme_content_outer.scss';
+		\gp\admin\Tools::$show_toolbar	= false;
+		$this->page->get_theme_css		= false;
+		$this->page->head_js[]			= '/include/js/auto_width.js';
+		$this->page->head_js[]			= '/include/js/theme_content_outer.js';
+		$this->page->css_admin[]		= '/include/css/theme_content_outer.scss';
 
 
 		//show site in iframe

--- a/include/admin/Layout/Edit.php
+++ b/include/admin/Layout/Edit.php
@@ -139,6 +139,7 @@ class Edit extends \gp\admin\Layout{
 
 		$_REQUEST					+= array('gpreq' => 'body'); //force showing only the body as a complete html document
 		$this->page->get_theme_css		= false;
+		\gp\admin\Tools::$show_toolbar	= false;
 
 		$this->page->css_user[]		= '/include/thirdparty/codemirror/lib/codemirror.css';
 		$this->page->head_js[]		= '/include/thirdparty/codemirror/lib/codemirror.js';

--- a/include/admin/Menu.php
+++ b/include/admin/Menu.php
@@ -1356,10 +1356,10 @@ class Menu extends \gp\special\Base{
 
 		if( $data['special'] === false ){
 			echo \gp\tool::Link(
-				$title,
+				'Admin/Revisions/'.$menu_key,
 				$langmessage['Revision History'],
 				'cmd=ViewHistory',
-				'class="view_edit_link not_multiple" data-cmd="gpabox"'
+				'class="view_edit_link not_multiple"'
 			);
 			echo $this->Link(
 				'Admin/Menu/Ajax',

--- a/include/admin/Page.php
+++ b/include/admin/Page.php
@@ -233,6 +233,7 @@ class Page extends \gp\Page{
 		//resolve request for /Admin_Theme_Content if the request is for /Admin_Theme_Conent/1234
 		$request_string		= str_replace('_','/',$this->requested);
 		$parts				= explode('/',$request_string);
+		$extra_parts		= [];
 
 		do{
 
@@ -243,7 +244,7 @@ class Page extends \gp\Page{
 				if( \gp\admin\Tools::HasPermission($request_string) ){
 
 					$this->OrganizeFrequentScripts($request_string);
-					\gp\tool\Output::ExecInfo($scriptinfo, array('page'=>$this) );
+					\gp\tool\Output::ExecInfo($scriptinfo, array('page'=>$this,'path_parts'=>$extra_parts) );
 
 					return;
 				}
@@ -264,7 +265,7 @@ class Page extends \gp\Page{
 				break;
 
 			}
-			array_pop($parts);
+			$extra_parts[] = array_pop($parts);
 
 		}while( count($parts) );
 

--- a/include/admin/Tools.php
+++ b/include/admin/Tools.php
@@ -312,6 +312,10 @@ namespace gp\admin{
 																'permission'	=> 'Admin/Notifications',
 													);
 
+			$scripts['Admin/Revisions']				= array(	'class'		=> '\\gp\\admin\\Content\\Revisions',
+																'method'	=> 'RunCommands',
+													);
+
 			// Addon admin links
 			if( isset($config['admin_links']) && is_array($config['admin_links']) ){
 
@@ -472,6 +476,9 @@ namespace gp\admin{
 			if( !self::$show_toolbar ){
 				return;
 			}
+
+
+			\gp\tool::LoadComponents('gp-admin-toolbar');
 
 			$reqtype = \gp\tool::RequestType();
 			if( $reqtype != 'template' && $reqtype != 'admin' ){

--- a/include/admin/Tools.php
+++ b/include/admin/Tools.php
@@ -312,8 +312,8 @@ namespace gp\admin{
 																'permission'	=> 'Admin/Notifications',
 													);
 
-			$scripts['Admin/Revisions']				= array(	'class'		=> '\\gp\\admin\\Content\\Revisions',
-																'method'	=> 'RunCommands',
+			$scripts['Admin/Revisions']				= array(	'class'			=> '\\gp\\admin\\Content\\Revisions',
+																'method'		=> 'RunScript',
 													);
 
 			// Addon admin links

--- a/include/admin/Tools/Iframe.php
+++ b/include/admin/Tools/Iframe.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace gp\admin\Tools;
+
+defined('is_running') or die('Not an entry point...');
+
+class Iframe{
+
+
+	/**
+	 *
+	 * @param [type] $iframe_src
+	 * @param [type] $content
+	 */
+	public static function Output( $page, $iframe_src, $toolbar, $content){
+
+		$_REQUEST += array('gpreq' => 'body'); //force showing only the body as a complete html document
+
+		\gp\tool::LoadComponents('resizable,gp-admin-css');
+
+		\gp\admin\Tools::$show_toolbar	= false;
+		$page->get_theme_css			= false;
+		$page->head_js[]				= '/include/js/auto_width.js';
+		$page->head_js[]				= '/include/js/theme_content_outer.js';
+		$page->css_admin[]				= '/include/css/theme_content_outer.scss';
+
+
+		//show site in iframe
+		echo '<div id="gp_iframe_wrap">';
+		echo '<iframe src="'.$iframe_src.'" id="gp_layout_iframe" name="gp_layout_iframe"></iframe>';
+		echo '</div>';
+
+		ob_start();
+
+		//new
+		echo '<div id="theme_editor">';
+		echo '<div class="gp_scroll_area">';
+
+
+		echo '<div>';
+		echo $toolbar;
+		echo '</div>';
+
+
+		echo '<div class="separator"></div>';
+		echo '<div id="available_wrap"><div>';
+
+		echo $content;
+
+		echo '</div></div>';
+		echo '</div>';
+
+		echo '</div>';
+		$page->admin_html = ob_get_clean();
+	}
+
+
+}

--- a/include/admin/Tools/Iframe.php
+++ b/include/admin/Tools/Iframe.php
@@ -20,7 +20,6 @@ class Iframe{
 
 		\gp\admin\Tools::$show_toolbar	= false;
 		$page->get_theme_css			= false;
-		$page->head_js[]				= '/include/js/auto_width.js';
 		$page->head_js[]				= '/include/js/theme_content_outer.js';
 		$page->css_admin[]				= '/include/css/theme_content_outer.scss';
 

--- a/include/admin/Tools/Iframe.php
+++ b/include/admin/Tools/Iframe.php
@@ -8,9 +8,13 @@ class Iframe{
 
 
 	/**
+	 * Output iframe interface
+	 * 
+	 * @param /gp/Page $page
+	 * @param string $iframe_src
+	 * @param string $toolbar
+	 * @param string $content
 	 *
-	 * @param [type] $iframe_src
-	 * @param [type] $content
 	 */
 	public static function Output( $page, $iframe_src, $toolbar, $content){
 

--- a/include/css/admin.scss
+++ b/include/css/admin.scss
@@ -6,7 +6,6 @@
 @import 'mixins.scss';
 @import 'variables.scss';
 
-@import 'admin_toolbar.scss';
 
 /**
  * Reset CSS

--- a/include/css/admin.scss
+++ b/include/css/admin.scss
@@ -710,6 +710,19 @@ body.gpAdmin div.editable_area{
 	&.middle > tbody > tr > td{
 		vertical-align: middle;
 	}
+
+	&.hover > tbody > tr:hover > td{
+		background-color: #ddd;
+	}
+
+ 	> tbody > tr.active > td{
+		background-color: #329880 !important;
+		&,
+		> a{
+			color: #fff !important;
+		}
+	}
+
 }
 
 

--- a/include/css/admin.scss
+++ b/include/css/admin.scss
@@ -43,8 +43,8 @@
 	text-shadow: none;
 	@include box-sizing( content-box );
 	/* background: none; prevents other backgrounds from showing. "inherit" wouldn't make sense */
-	font-family: inherit; 
-	font-size: inherit; 
+	font-family: inherit;
+	font-size: inherit;
 	line-height: inherit; //* conflicts with fontawesome */
 }
 
@@ -656,7 +656,7 @@ body.edit_layout .GPAREA{
 }
 
 body.gpAdmin .GPAREA[data-gp_hidden="true"]{
-	display: none!important; 
+	display: none!important;
 }
 
 body.gpAdmin div.editable_area{
@@ -667,51 +667,56 @@ body.gpAdmin div.editable_area{
 /**
  * general
  */
+
+ .full_width,
+ #gp_admin_html .full_width{
+ 	width: 100%;
+ }
+
+
+#gp_admin_html .bordered,
 .bordered{
 	margin-top: 1em;
 	border-spacing: 0;
 	border-top: 1px solid #eee;
+
+
+	> tbody > tr > th,
+	> thead > tr > th,
+	> tbody > tr > td,
+	> tfoot > tr > td{
+		padding: 7px;
+		border-bottom: 1px solid #eee;
+		text-align: left;
+		color: #444 !important;
+		background-color: #fff;
+	}
+
+	> tbody > tr > th,
+	> thead > tr > th{
+		background-color: #eee;
+		white-space: nowrap;
+		color: #000;
+		text-shadow: 0 1px 0 #fff !important;
+		border-bottom: 1px solid #ddd;
+		font-weight: bold;
+	}
+
+	> tbody > tr.even > td,
+	&.striped tbody > tr:nth-child(2n) > td{
+		background: #f5f5f5;
+	}
+
+	&.middle > tbody > tr > td{
+		vertical-align: middle;
+	}
 }
 
-.full_width,
-#gp_admin_html .full_width{
-	width: 100%;
-}
-
-.bordered > tbody > tr > th,
-.bordered > thead > tr > th,
-.bordered > tbody > tr > td,
-.bordered > tfoot > tr > td{
-	padding: 7px;
-	border-bottom: 1px solid #eee;
-	text-align: left;
-	color: #444 !important;
-	background-color: #fff;
-}
-
-.bordered > tbody > tr > th,
-.bordered > thead > tr > th{
-	background-color: #eee;
-	white-space: nowrap;
-	color: #000;
-	text-shadow: 0 1px 0 #fff !important;
-	border-bottom: 1px solid #ddd;
-	font-weight: bold;
-}
-
-.bordered > tbody > tr.even > td,
-.bordered.striped tbody > tr:nth-child(2n) > td{
-	background: #f5f5f5;
-}
-
-#gp_admin_html .bordered.middle > tbody > tr > td{
-	vertical-align: middle;
-}
 
 
 
 /**
- * collapsible 
+ * collapsible
  */
 .collapsible h4{
 	margin: 0;
@@ -799,7 +804,7 @@ table.tablesorter th.gp_header_desc:before{
 
 
 /**
- * New Expandable Menu Control 
+ * New Expandable Menu Control
  */
 .expand_child,
 .expand_child_click{
@@ -832,7 +837,7 @@ table.tablesorter th.gp_header_desc:before{
 }
 
 /**
- * don't show any drop down menus when dragging 
+ * don't show any drop down menus when dragging
  */
 .drag_active ul{
 	display: none !important;
@@ -862,13 +867,13 @@ table.tablesorter th.gp_header_desc:before{
 
 /**
  * Admin Panel
- * This is the panel of admin links that is displayed 
+ * This is the panel of admin links that is displayed
  * across all pages when the user is logged in
  */
 
 
  /**
- * simple panel 
+ * simple panel
  */
 #simplepanel{
 	position: fixed;
@@ -1640,7 +1645,7 @@ body #addon_about{
 }
 
 /**
- * jquery ui autocomplete 
+ * jquery ui autocomplete
  */
 #gp_admin_html{
 
@@ -1708,7 +1713,7 @@ body #addon_about{
 
 
 /**
- * floating areas 
+ * floating areas
  */
 #gp_admin_box,
 .gp_floating_area{
@@ -1951,7 +1956,7 @@ body #addon_about{
 
 #gp_admin_html .classes-load-presets{
 	margin-top: 20px;
-			
+
 	ul{
 		margin:0.5em 0;
 		padding-left: 1.25em;
@@ -2027,7 +2032,7 @@ body #addon_about{
 
 
 /**
- * ckeditor & autocomplete conflict 
+ * ckeditor & autocomplete conflict
  */
 .cke_dialog_ui_input_text .ui-helper-hidden-accessible{
 	display: none;

--- a/include/css/admin_toolbar.scss
+++ b/include/css/admin_toolbar.scss
@@ -1,4 +1,5 @@
 
+@import 'variables.scss';
 
 body.gpAdmin #admincontent_panel.fixed{
 	position:fixed;
@@ -39,7 +40,7 @@ body.gpAdmin #admincontent_panel.fixed{
  * Fixed Position Adjustment when admin toolbar is displayed
  *
  */
-html:not(.edit_layout):not(.admin_body){
+html:not(.admin_body){
 	margin-top:$gp_nav_height;
 
 	.gp-fixed-adjust{

--- a/include/js/admin.js
+++ b/include/js/admin.js
@@ -716,6 +716,47 @@ $gp.links.rm_table_row = function(evt){
 	$this.closest('tr').remove();
 }
 
+
+/**
+ * POST a link (without ajax)
+ *
+ */
+$gp.links.post = function(evt){
+	evt.preventDefault();
+
+	var query			= strip_to(this.search,'?');
+	var params			= ParseQuery(query);
+	params.verified		= post_nonce;
+
+	var form			= document.createElement('form');
+
+    form.method			= 'POST';
+    form.action			= this.pathname;
+
+
+	for( const [name, value] of Object.entries(params) ){
+		var element		= document.createElement('input');
+		element.name	= name;
+		element.value	= value;
+	    form.appendChild(element);
+	}
+
+    document.body.appendChild(form);
+
+    form.submit();
+}
+
+function ParseQuery(queryString) {
+    var query = {};
+    var pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
+    for (var i = 0; i < pairs.length; i++) {
+        var pair = pairs[i].split('=');
+        query[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1] || '');
+    }
+    return query;
+}
+
+
 /**
  * Post a gpabox request
  *

--- a/include/js/admin/revision.js
+++ b/include/js/admin/revision.js
@@ -1,0 +1,11 @@
+
+$(function(){
+	/**
+	 * Adjust link targets to point at parent unless they're layout links
+	 *
+	 */
+	$('a').each(function(){
+		this.target = '_parent';
+	});
+
+});

--- a/include/js/admin/revisions.js
+++ b/include/js/admin/revisions.js
@@ -1,0 +1,62 @@
+
+$(function(){
+
+	var iframe		= document.getElementById('gp_layout_iframe');
+	var $rows		= $('#revision_rows').children();
+
+	$rows.find('[target=gp_layout_iframe]').hide();
+
+	/**
+	 * Show a revision
+	 *
+	 */
+	function ShowRevision($row){
+
+		if( !$row.length ){
+			return;
+		}
+
+		$rows.removeClass('active');
+		$row.addClass('active');
+
+		var href		= $row.find('a[target=gp_layout_iframe]').get(0).href;
+		iframe.src		= href;
+	}
+
+
+	/**
+	 * Handle clicks on table rows
+	 *
+	 */
+	$rows.click(function(evt){
+
+
+		if( evt.target.nodeName == 'A' ){
+			return;
+		}
+
+		var $this = $(this);
+		ShowRevision($this);
+
+
+	}).first().addClass('active');
+
+	/**
+	 * Show previous revision
+	 *
+	 */
+	$gp.links.PreviousRevision = function(){
+		var $row = $rows.filter('.active').prev();
+		ShowRevision($row);
+	}
+
+	/**
+	 * Show next revision
+	 *
+	 */
+	$gp.links.NextRevision = function(){
+		var $row = $rows.filter('.active').next();
+		ShowRevision($row);
+	}
+
+});

--- a/include/js/theme_content.js
+++ b/include/js/theme_content.js
@@ -109,7 +109,7 @@ $(function(){
 	 */
 	function LayoutSetup(){
 
-		$('html').addClass('edit_layout'); //for .gp-fixed-adjust
+		$('html').addClass('edit_layout');
 
 		if( typeof(gpLayouts) == 'undefined' ){
 			return;

--- a/include/tool/Output/Combine.php
+++ b/include/tool/Output/Combine.php
@@ -27,6 +27,11 @@ class Combine{
 									'requires'		=> 'ui-theme',
 									),
 
+			'gp-admin-toolbar' => array(
+									'file'			=> '/include/css/admin_toolbar.scss',
+									'type'			=> 'css',
+									),
+
 			'gp-additional'=> array(
 									'file'			=> '/include/css/additional.css',
 									'type'			=> 'css',


### PR DESCRIPTION
I think the revision history interface could use an overhaul. Here are my primary complaints about the existing design:
* The list of revisions closes each time a different version is viewed
* Clicking "Previous" and "Next" links in the toolbar don't give the user context of where they're at in the revision history

Here's my new take using a sidebar like the one used for layout editing. What do you all think?

![Revision History](https://user-images.githubusercontent.com/1043524/71793762-86051c00-2ffb-11ea-9dd6-43803340efb0.png)

