### PR TITLE
Replace trigger point for event 'editor_area:loaded'

### DIFF
--- a/include/js/inline_edit/inline_editing.js
+++ b/include/js/inline_edit/inline_editing.js
@@ -266,7 +266,6 @@
 				$('#gp_admin_html').append(html);
 
 				$('html').addClass('gpEditing');
-				$(document).trigger('editor_area:loaded');
 
 				$ck_area_wrap = $('#ck_area_wrap');
 			}
@@ -283,7 +282,7 @@
 			html += '</div>';
 			$ck_area_wrap.html(html);
 
-			$(document).trigger('editor_area:shown');
+			$(document).trigger('editor_area:loaded');
 			gp_editing.ShowEditor();
 		},
 

--- a/include/js/inline_edit/inline_editing.js
+++ b/include/js/inline_edit/inline_editing.js
@@ -283,6 +283,7 @@
 			html += '</div>';
 			$ck_area_wrap.html(html);
 
+			$(document).trigger('editor_area:shown');
 			gp_editing.ShowEditor();
 		},
 


### PR DESCRIPTION
Can I ask for a new JS event when editor is shown.
The 'editor_area:loaded' is not sufficient to catch the moment when, e.g., the gallery editor is changed to the pure CKeditor or the plugin section editor and vice versa. 
I need it for my CKE_Themes plugin.