### PR TITLE
Make CKE dialogs height same for all tabs

### DIFF
--- a/include/js/ckeditor_config.js
+++ b/include/js/ckeditor_config.js
@@ -143,5 +143,20 @@ CKEDITOR.on( 'dialogDefinition', function( ev ){
 
 			}
 		});
+
+		dialogDefinition.height = 280;
 	}
+	
+	if ( dialogName == 'find' ) {
+		dialogDefinition.height = 200;
+	}
+
+	if( dialogName == 'image' ){
+		dialogDefinition.height = 430;
+	}
+
+	if( dialogName == 'table' ){
+		dialogDefinition.height = 370;
+	}  		
+	
 });


### PR DESCRIPTION
Now the height of the dialogs does not jump when the user changes the tabs.

Note. It is a legal method used in some CKE themes

Before
![image](https://user-images.githubusercontent.com/14929385/72373689-7e3b2b00-3711-11ea-82e3-97745ae4696d.png)![image](https://user-images.githubusercontent.com/14929385/72373764-a0cd4400-3711-11ea-9850-2aebf7615e83.png)

After
![image](https://user-images.githubusercontent.com/14929385/72373856-c9553e00-3711-11ea-8ffd-9ffb7a88cec1.png)


