### PR TITLE
Exclude section type 'Image' from Extra area

### DIFF
--- a/include/admin/Content/Extra.php
+++ b/include/admin/Content/Extra.php
@@ -315,6 +315,7 @@ class Extra extends \gp\Page\Edit{
 		$types	= \gp\tool\Output\Sections::GetTypes();
 		$_types	= [];
 		foreach( $types as $type => $info ){
+			if ( $type != 'image')
 			$_types[$type] = $info['label'];
 		}
 


### PR DESCRIPTION
Radical fix for https://github.com/Typesetter/Typesetter/issues/506