### PR TITLE
Avoid additional Sections Link before Section name

### DIFF
--- a/include/js/inline_edit/inline_editing.js
+++ b/include/js/inline_edit/inline_editing.js
@@ -322,6 +322,7 @@
 			//tabs
 			var $tabs			= $('#ckeditor_tabs').html('');
 			var extra_mode		= gp_editing.IsExtraMode();
+			var label = false;
 
 			if( extra_mode ){
 				$ckeditor_wrap.addClass('edit_mode_extra');
@@ -329,14 +330,13 @@
 					+ 'data-arg="manage_sections" title="' + gplang.Extra + '">' + gplang.Extra + '</a>');
 			}else{
 				$ckeditor_wrap.removeClass('edit_mode_extra');
-				$tabs.append('<a href="?cmd=ManageSections" data-cmd="inline_edit_generic" '
-					+ 'data-arg="manage_sections" title="' + gplang.Sections + '">' + gplang.Sections + '</a>');
-			}
-
-			var label = false;
-			if( $edit_area.length != 0 ){
-				label			= gp_editing.SectionLabel($edit_area);
-				$('<a>').attr('title', label).text(label).appendTo( $tabs );
+				if( $edit_area.length != 0 ){
+					label			= gp_editing.SectionLabel($edit_area);
+					$('<a>').attr('title', label).text(label).appendTo( $tabs );
+				} else {
+					$tabs.append('<a href="?cmd=ManageSections" data-cmd="inline_edit_generic" '
+						+ 'data-arg="manage_sections" title="' + gplang.Sections + '">' + gplang.Sections + '</a>');
+				}	
 			}
 
 			// Hide save buttons for extra content list


### PR DESCRIPTION
Does all this href="?cmd=ManageSections" have a sense beside being just a link for proper styling by CKE?