### PR TITLE
Drop-down classes list on caret click

### DIFF
--- a/include/css/manage_sections.css
+++ b/include/css/manage_sections.css
@@ -366,17 +366,16 @@ ul#section-clipboard-items li.clipboard-empty-msg {
 }
 
 #gp_avail_classes label.gpcheckbox select {
-	margin-right: 0 !important;
+	margin-right: -10px !important;
 	padding: 0 16px 0 0 !important;
 	position: relative;
 	margin-left: -4px;
-	width: 134px;
+	width: 144px;
 	border: none !important;
 	border-radius: 0 !important;
 	appearance: none;
 	-webkit-appearance: none;
 	-moz-appearance: none;
-	appearance: none;
 	background: none;
 	outline: none;
 	cursor: pointer;


### PR DESCRIPTION
It expands `<select>` to cover caret sign and to allow to drop down the options instead of checking the box on click.

![image](https://user-images.githubusercontent.com/14929385/72851679-f925b800-3cb4-11ea-9750-0bb84b05e7e1.png)
