### PR TITLE
Fix for input "text" shift down in Chrome for 3.5

### DIFF
--- a/themes/Three_point_5/Shore/style.css
+++ b/themes/Three_point_5/Shore/style.css
@@ -164,6 +164,9 @@ p{
 	background: rgba(62,59,57,0.5);
 	padding:0;
 }
+#search div{
+	display: flex;
+}
 #search input{
 	height:14px;
 	padding: 8px;


### PR DESCRIPTION
Chrome (and Opera too:) without this patch
![image](https://user-images.githubusercontent.com/14929385/72990418-c71d6e80-3df8-11ea-8cab-709796abded9.png)
IE
![image](https://user-images.githubusercontent.com/14929385/72990654-37c48b00-3df9-11ea-9fe8-615cbc8d41b1.png)

Chrome with this patch
![image](https://user-images.githubusercontent.com/14929385/72990776-74908200-3df9-11ea-8386-c0e2e3fdb50b.png)

I hope FF too will have the benefits or no problems.