### PR TITLE
Get section_object as argument

### DIFF
--- a/include/js/inline_edit/gallery_edit_202.js
+++ b/include/js/inline_edit/gallery_edit_202.js
@@ -266,7 +266,7 @@
 
 		ShowEditor();
 		var orig_content			= gp_editor.getData(gp_editor.edit_div, section_object);
-		gp_editor.editorLoaded();
+		gp_editor.editorLoaded(section_object);
 
 
 		function ShowEditor(){


### PR DESCRIPTION
Juergen. 
It is more a question than a suggestion.

I want to extend gallery editor in my Bootstrap carousel fork. 
To be precise, I want to insert additional checkbox to gallery_edit_202.js gp_editor.

![image](https://user-images.githubusercontent.com/14929385/73035691-c49b3300-3e51-11ea-9aaa-f882605068b0.png)

As I see it, section_object  is needed to read the stored editor data.
Am I right? Is this PR permissible, or can I solve my task without it?

As I can see, GalleryEditorTweaks is the only user of gp_editor.editorLoaded() hook. It works fine after the argument has been added to the function.