### PR TITLE
Load hook before original content is determined

### DIFF
--- a/include/js/inline_edit/gallery_edit_202.js
+++ b/include/js/inline_edit/gallery_edit_202.js
@@ -265,8 +265,8 @@
 		//gp_editor.edit_div.get(0).innerHTML = section_object.content;
 
 		ShowEditor();
-		var orig_content			= gp_editor.getData(gp_editor.edit_div, section_object);
 		gp_editor.editorLoaded(section_object);
+		var orig_content = gp_editor.getData(gp_editor.edit_div, section_object);
 
 
 		function ShowEditor(){


### PR DESCRIPTION
Currently, adding controls in 'editorLoaded' causes a false 'changed' state and prevents the detection of changes in state of added controls. The patch (in fact, lines reorder) fixes this.