### PR TITLE
'Copy' instead of 'New Page' (as on Insert Into Menu >> Insert Before)

### DIFF
--- a/include/admin/Menu/Ajax.php
+++ b/include/admin/Menu/Ajax.php
@@ -176,7 +176,7 @@ class Ajax extends \gp\admin\Menu{
 			}
 		}
 		\gp\admin\Menu\Tools::ScrollList($gp_index_no_special);
-		echo sprintf($format_bottom, 'CopyPage', $langmessage['create_new_file']);
+		echo sprintf($format_bottom, 'CopyPage', $langmessage['Copy']);
 
 
 		//content type


### PR DESCRIPTION
Now they will be similar and more clear

Insert Into Menu >> Insert Before
![image](https://user-images.githubusercontent.com/14929385/73134398-b9f1c100-403e-11ea-965e-584917f56928.png)

\+ Create New Page
![image](https://user-images.githubusercontent.com/14929385/73134407-cbd36400-403e-11ea-8078-ba30a43a531a.png)

