### PR TITLE
Make non-active Rev.Hist. item edit links disabled

### DIFF
--- a/include/css/theme_content_outer.scss
+++ b/include/css/theme_content_outer.scss
@@ -78,6 +78,10 @@ body {
 				}
 			}
 		}
+		tr:not(.active) td.revision_history_links a{
+			color:#ccc;
+			pointer-events: none;
+		}
 		td.revision_history_username {
 			overflow: hidden;
 			white-space: nowrap;


### PR DESCRIPTION
It's for https://github.com/Typesetter/Typesetter/issues/560#issuecomment-581774573

We can also set visibility to hidden.
