### PR TITLE
Do not show special pages as Not Found proposition

### DIFF
--- a/include/special/Missing.php
+++ b/include/special/Missing.php
@@ -252,7 +252,7 @@ class Missing extends \gp\special\Base{
 			//skip private pages
 			if( !$admin ){
 
-				if( isset($gp_titles[$index]['vis']) ){
+				if( isset($gp_titles[$index]['vis']) || \gp\tool::SpecialOrAdmin($title) == 'special' ){
 					continue;
 				}
 			}

--- a/include/special/Missing.php
+++ b/include/special/Missing.php
@@ -232,8 +232,9 @@ class Missing extends \gp\special\Base{
 		foreach($similar as $title => $percent_similar){
 			$result .= \gp\tool::Link_Page($title).', ';
 		}
-		if( !$admin && (!isset($config['showsitemap']) || $config['showsitemap'] ) )
-		{ $result .= \gp\tool::Link_Page('Site_Map'); }
+		if( !$admin && (!isset($config['showsitemap']) || $config['showsitemap'] ) ){ 
+			$result .= \gp\tool::Link_Page('Site_Map');
+		}
 
 		return rtrim($result,', ');
 	}

--- a/include/special/Missing.php
+++ b/include/special/Missing.php
@@ -231,6 +231,7 @@ class Missing extends \gp\special\Base{
 		foreach($similar as $title => $percent_similar){
 			$result .= \gp\tool::Link_Page($title).', ';
 		}
+		if( !$admin ){ $result .= \gp\tool::Link_Page('Site_Map'); }
 
 		return rtrim($result,', ');
 	}

--- a/include/special/Missing.php
+++ b/include/special/Missing.php
@@ -223,6 +223,7 @@ class Missing extends \gp\special\Base{
 	 *
 	 */
 	public function SimilarTitles(){
+		global $config;
 
 		$similar	= $this->SimilarTitleArray($this->requested);
 		$similar	= array_slice($similar,0,7,true);
@@ -231,7 +232,8 @@ class Missing extends \gp\special\Base{
 		foreach($similar as $title => $percent_similar){
 			$result .= \gp\tool::Link_Page($title).', ';
 		}
-		if( !$admin ){ $result .= \gp\tool::Link_Page('Site_Map'); }
+		if( !$admin && (!isset($config['showsitemap']) || $config['showsitemap'] ) )
+		{ $result .= \gp\tool::Link_Page('Site_Map'); }
 
 		return rtrim($result,', ');
 	}


### PR DESCRIPTION
I have always wondered why we propose the user to view pages with special content?

Before
![image](https://user-images.githubusercontent.com/14929385/73786895-d7dbc600-47a2-11ea-9917-a5e202634641.png)

After
![image](https://user-images.githubusercontent.com/14929385/73786915-ddd1a700-47a2-11ea-9e28-2307a023d9f0.png)
