### PR TITLE
Show only relevant propositions in 'Not Found'

### DIFF
--- a/include/special/Missing.php
+++ b/include/special/Missing.php
@@ -229,7 +229,9 @@ class Missing extends \gp\special\Base{
 		$result		= '';
 
 		foreach($similar as $title => $percent_similar){
-			$result .= \gp\tool::Link_Page($title).', ';
+			if ( $title === key($similar) || $percent_similar > 10 ) {
+				$result .= \gp\tool::Link_Page($title).', ';
+			}
 		}
 
 		return rtrim($result,', ');


### PR DESCRIPTION
We always show 7 propositions in 'Not Found' page, but not all of them are truly relevant. This patch introduces a threshold for title similarity, but always shows at least one proposition.

Let's try to open page e.g. 'їж'.

Before
![image](https://user-images.githubusercontent.com/14929385/73794446-255f2f80-47b1-11ea-956a-e3bea6ee9081.png)

After
![image](https://user-images.githubusercontent.com/14929385/73794461-2ee89780-47b1-11ea-8afc-1c99ecdae6f2.png)


