### PR TITLE
Use multibyte lowercase to search similar pages

### DIFF
--- a/include/special/Missing.php
+++ b/include/special/Missing.php
@@ -259,7 +259,7 @@ class Missing extends \gp\special\Base{
 				}
 			}
 
-			similar_text($lower,strtolower($title),$percent);
+			similar_text($lower,mb_strtolower($title),$percent);
 			$similar[$title] = $percent;
 		}
 


### PR DESCRIPTION
Now the lowercase() does not work with Unicode symbols at all, e.g. with Cyrillic.
I think, it fails to manage uppercase umlauts as well. Have you noticed?