### PR TITLE
Load fontawesome for admin links icons

### DIFF
--- a/themes/Bootswatch4_Scss/template.php
+++ b/themes/Bootswatch4_Scss/template.php
@@ -29,6 +29,7 @@ $lang = isset($page->lang) ? $page->lang : $config['language'];
 
     <?php
       common::LoadComponents( 'bootstrap4-js' );
+      common::LoadComponents( 'fontawesome' );
       gpOutput::GetHead();
     ?>
 


### PR DESCRIPTION
Without loading the Fontawesome we have such a situation.

![image](https://user-images.githubusercontent.com/14929385/74568308-58a77880-4f80-11ea-8692-f0886778810f.png)
