### PR TITLE
Filter page for Missing suggestions

### DIFF
--- a/include/special/Missing.php
+++ b/include/special/Missing.php
@@ -245,6 +245,11 @@ class Missing extends \gp\special\Base{
 	public function SimilarTitleArray($title){
 		global $gp_index, $gp_titles;
 
+		$similar_blacklist = \gp\admin\Menu\Tools::GetAvailable();
+		unset($similar_blacklist['special_site_map']);
+		unset($similar_blacklist['special_blog']);
+
+
 		$similar			= array();
 		$lower				= str_replace(' ','_',strtolower($title));
 		$admin				= \gp\tool::LoggedIn();
@@ -253,8 +258,8 @@ class Missing extends \gp\special\Base{
 
 			//skip private pages
 			if( !$admin ){
-
-				if( isset($gp_titles[$index]['vis']) ){
+				
+				if( isset($gp_titles[$index]['vis']) || in_array($title, $similar_blacklist) ){
 					continue;
 				}
 			}


### PR DESCRIPTION
Another approach.
I reject all pages that are not in the Main menu.
But, 'Site Map' and 'Blog' will always be suggested on Missing page as they are well always formatted pages.

Why?
I no longer want to see in Google search results links to the hidden or internal pages that it found in "Were you looking for" list.