### PR TITLE
add 'local' constant to use in debug options

### DIFF
--- a/gpconfig.php
+++ b/gpconfig.php
@@ -1,5 +1,7 @@
 <?php
 
+define("local", !filter_var($_SERVER['SERVER_ADDR'], FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE));
+
 /**
  * $upload_extensions_allow and $upload_extensions_deny
  * Allow or deny the upload of files based on their file extensions


### PR DESCRIPTION
Proof of concept.

It allows defining 'gpdebug' as
`defined('gpdebug') or define('gpdebug', local);`

So, when TS is run on local server 'gpdebug' is **ON** and when TS is run on live web server 'gpdebug' is **OFF**