### PR TITLE
Prevent text selection starting from Clipboard

### DIFF
--- a/include/css/manage_sections.css
+++ b/include/css/manage_sections.css
@@ -279,6 +279,7 @@ ul#section-clipboard-items li {
 	margin: 0 0 3px 0;
 	padding: 2px 2px 2px 14px;
 	cursor: pointer;
+	user-select: none;
 }
 
 ul#section-clipboard-items li a.preview_section {


### PR DESCRIPTION
To prevent this situation when pressing on the clipboard item and dragging mouse

![image](https://user-images.githubusercontent.com/14929385/77223333-36e37780-6b64-11ea-9366-efd00effb903.png)
