### PR TITLE
Remove jitter in section dropdown edit menu

### DIFF
--- a/include/css/admin.scss
+++ b/include/css/admin.scss
@@ -92,7 +92,6 @@
 	font-style: normal;
 	text-decoration: none;
 	text-transform: none;
-	border: 0 none;
 }
 #gp_admin_html a:hover {
 	color: $link-hover-color;


### PR DESCRIPTION
When I move cursor through menu hovered element changes size.
![image](https://user-images.githubusercontent.com/14929385/77691140-1294fa00-6fad-11ea-8f35-cd939fd3c5d4.png)
