### PR TITLE
New google font import style

### DIFF
--- a/themes/Bootswatch4_Scss/united/variables.scss
+++ b/themes/Bootswatch4_Scss/united/variables.scss
@@ -42,7 +42,7 @@ $yiq-contrasted-threshold: 200;
 $body-color: $gray-800;
 
 // Fonts
-$web-font-path: "https://fonts.googleapis.com/css?family=Ubuntu:400,700";
+$web-font-path: "https://fonts.googleapis.com/css?family=Ubuntu:wght@400;700";
 $font-family-sans-serif: "Ubuntu", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 $font-size-base: 1rem;
 $navbar-font-size: 1rem;


### PR DESCRIPTION
I do not know why, but with old style of import, Cyrillic subset of this Ubuntu font looks distorted. With `:wght@` font is OK.

Count this like proof of concept.