### PR TITLE
Introduce active highlighted class

### DIFF
--- a/include/css/manage_sections.css
+++ b/include/css/manage_sections.css
@@ -41,6 +41,10 @@
 	outline-offset: -1px;
 }
 
+#section_sorting li.section-sorting-highlight.active {
+	box-shadow: 0 0 2px black;
+}
+
 #section_sorting .color_handle {
 	position: absolute;
 	top: 0;

--- a/include/js/inline_edit/manage_sections.js
+++ b/include/js/inline_edit/manage_sections.js
@@ -433,9 +433,16 @@
 
 				// highlight sections in editor
 				$this.on("mouseenter", function(){
-					$('li[data-gp-area-id="' + area_id + '"]').addClass('section-sorting-highlight');
+					$('li[data-gp-area-id].section-sorting-highlight.active')
+					.not($('li[data-gp-area-id="' + area_id + '"]').parents('li'))
+					.not($('li[data-gp-area-id="' + area_id + '"]').find('li'))
+					.removeClass('active');
+				
+					$('li[data-gp-area-id="' + area_id + '"]').addClass('section-sorting-highlight')
+					.addClass('active');
 				}).on("mouseleave", function(){
-					$('li[data-gp-area-id="' + area_id + '"]').removeClass('section-sorting-highlight');
+					$('li[data-gp-area-id="' + area_id + '"]').removeClass('section-sorting-highlight')
+					.removeClass('active');
 				});
 
 


### PR DESCRIPTION
PC for https://github.com/Typesetter/Typesetter/issues/636#issue-613129027

This adds shadows to the hovered section to distinguish it from other edited (and therefore also highlighted) sections.
![image](https://user-images.githubusercontent.com/14929385/85456636-d707cd00-b5a7-11ea-8602-d2950b009d21.png)

EDIT/Disclaimer
Shadow, colour, etc. are, a matter of taste:)