### PR TITLE
fix missed protocol in Site_Map?xml

### DIFF
--- a/include/special/Map.php
+++ b/include/special/Map.php
@@ -77,7 +77,7 @@ class Map extends \gp\special\Base{
 				echo "\n";
 				echo '<url>';
 				echo '<loc>';
-				echo isset($info['url']) ? $info['url'] : \gp\tool::AbsoluteUrl($title,'','','',true);
+				echo isset($info['url']) ? $info['url'] : \gp\tool::AbsoluteUrl($title,'',true,'',true);
 				echo '</loc>';
 				echo '</url>';
 			}


### PR DESCRIPTION
Google does not like URL without http:// in site map
Thus 

Before
![image](https://user-images.githubusercontent.com/14929385/87244831-ec567580-c448-11ea-8302-485f6259ec93.png)

After
![image](https://user-images.githubusercontent.com/14929385/87244849-07c18080-c449-11ea-901b-8cb22c5c6857.png)

