### PR TITLE
Fix for always shown 3rd level menu

### DIFF
--- a/themes/Bootstrap4/_common/menu.js
+++ b/themes/Bootstrap4/_common/menu.js
@@ -16,9 +16,9 @@ $(function(){
 
 		var $toggle = !$this.hasClass('dropdown-active');
 
-		if( !$toggle ){
-			$parent_li.find('.dropdown-item').removeClass('dropdown-active');
-			$parent_li.find('.show').removeClass('show');
+		if( $toggle ){
+			$parent_li.siblings('li').find('.dropdown-item').removeClass('dropdown-active');
+			$parent_li.siblings('li').find('.show').removeClass('show');
 		}
 
 		$this.toggleClass('dropdown-active', $toggle);


### PR DESCRIPTION
Currently, it is possible to open more than one 3rd level dropdown menu at a time. I have found such a fix for this issue.