### PR TITLE
Better support for non Latin characters

### DIFF
--- a/include/special/Search.php
+++ b/include/special/Search.php
@@ -384,7 +384,7 @@ class Search extends \gp\special\Base{
 			$sub_pattern2[] = preg_quote($word, '#');
 		}
 
-		$this->search_pattern = '#(?:(' . implode('|', $sub_pattern1) . ')|(' . implode('|', $sub_pattern2) . '))#Si';
+		$this->search_pattern = '#(?:(' . implode('|', $sub_pattern1) . ')|(' . implode('|', $sub_pattern2) . '))#Siu';
 	}
 
 


### PR DESCRIPTION
Now Cyrillic search is truly case-insensitive.

Tip from https://stackoverflow.com/questions/5510439/regular-expression-for-validating-cyrillic